### PR TITLE
add a constant pseudo-prior that returns the same user-provided values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Added
 - Support for multiple additive terms.
+- Constant pseudo-prior. When used for weights, this can be used to project new data into an already existing latent space.
 
 ### Changed
 - The `show_featurenames` argument to `pl.factor` is now called `show_samplenames` to better reflect what it actually does.

--- a/src/mofaflex/_core/datasets/base.py
+++ b/src/mofaflex/_core/datasets/base.py
@@ -176,6 +176,12 @@ class MofaFlexDataset(Dataset, ABC):
         """Feature names for each view."""
         pass
 
+    def get_names(self, axis: Literal[0, 1, "samples", "features"]) -> dict[str, NDArray[str]]:
+        if axis in (0, "samples"):
+            return self.sample_names
+        else:
+            return self.feature_names
+
     def __len__(self):
         """Length of this dataset."""
         return max(self.n_samples.values())

--- a/src/mofaflex/_core/priors/__init__.py
+++ b/src/mofaflex/_core/priors/__init__.py
@@ -1,6 +1,7 @@
 from typing import Literal, TypeAlias
 
 from .base import API, APIType, Prior
+from .constant import Constant
 from .gaussian_process import GaussianProcess
 from .horseshoe import InformedHorseshoe
 from .simple_location_scale import *  # noqa F403

--- a/src/mofaflex/_core/priors/base.py
+++ b/src/mofaflex/_core/priors/base.py
@@ -72,10 +72,8 @@ class Prior(SaveStateMixin, ABC, PyroModule, metaclass=_PyroMeta):
     _state_attrs = "_names"
 
     def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-
         if not isabstract(cls) and cls.__name__[0] != "_":
-            if not cls._factors_allowed and not cls._weights_allowed:
+            if not cls.factors_allowed() and not cls.weights_allowed():
                 raise TypeError(f"Class `{cls.__name__}` cannot be used for factors or weights.")
 
     def __init__(self, names: str | Sequence[str]):
@@ -163,6 +161,17 @@ class Prior(SaveStateMixin, ABC, PyroModule, metaclass=_PyroMeta):
     def api_properties(cls) -> Iterable[API]:
         """The user-facing properties of this prior."""
         return (api for api in cls._apilist if api.type == APIType.property)
+
+    def _reshape_tensor_to_batch(
+        self, tens: torch.Tensor, name: str, factor_plate: pyro.plate, nonfactor_plate: pyro.plate
+    ):
+        shape = self._shapes[name]
+        if tens.shape[0] < nonfactor_plate.size:
+            shape = list(shape)
+            shape[nonfactor_plate.dim] = tens.shape[0]
+        if factor_plate.dim < nonfactor_plate.dim:
+            tens = tens.T
+        return tens.reshape(shape)
 
     def get_datasets(
         self,

--- a/src/mofaflex/_core/priors/constant.py
+++ b/src/mofaflex/_core/priors/constant.py
@@ -1,0 +1,76 @@
+from collections.abc import Mapping, Sequence
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import pyro
+import torch
+
+from ..datasets import MofaFlexDataset
+from ..utils import MeanStd
+from .base import Prior
+
+
+class Constant(Prior):
+    """Pseudo-prior that always returns the same constant values.
+
+    When used for weights, this can be used to project new data into an already existing latent space.
+
+    Args:
+        const_values: The constant values to use for each group/view. Must have factors in columns and
+            samples/features in rows. The number of factors must match the configuration of the model
+            this prior is being used with. Sample/feature names must be a superset of the sample/feature
+            names of the data this prior is being used with.
+    """
+
+    def __init__(self, names: str | Sequence[str], const_values: Mapping[str, pd.DataFrame]):
+        super().__init__(names)
+        if len(difference := set(names) - const_values.keys()) > 0:
+            raise ValueError(f"The mapping given for 'const_values' is missing entries for {', '.join(difference)}.")
+        if len({const.shape[1] for const in const_values.values()}) > 1:
+            raise ValueError("The provided 'const_values' have different numbers of factors")
+        self._const_values = const_values
+
+    def get_datasets(
+        self,
+        data: MofaFlexDataset,
+        axis: Literal[0, 1],
+        factor_dim: int,
+        nonfactor_dim: int,
+        n_factors: int,
+        n_nonfactors: Mapping[str, int],
+    ) -> dict[str, dict[str, pd.DataFrame | np.ndarray]]:
+        data_names = data.get_names(axis)
+        vals = {}
+        tvals = {}
+        for name in self.names:
+            const_val = self._const_values[name]
+            if (const_n_factors := const_val.shape[1]) != n_factors:
+                raise ValueError(
+                    f"The constant values for '{name}' have the wrong number of factors: Expected {n_factors}, got {const_n_factors}."
+                )
+
+            val = const_val.loc[data_names[name], :].to_numpy()
+            vals[name] = val
+            tvals[name] = torch.as_tensor(
+                val.T if factor_dim < nonfactor_dim else val, device="cpu"
+            )  # for post-training processing in the MofaFlex term
+        self._const_values = tvals
+        return {"const": vals}
+
+    def _model(
+        self,
+        id: str,
+        name: str,
+        factor_plate: pyro.plate,
+        nonfactor_plate: pyro.plate,
+        const: Mapping[str, torch.Tensor],
+        **kwargs,
+    ):
+        return self._reshape_tensor_to_batch(const[name], name, factor_plate, nonfactor_plate)
+
+    _guide = _model
+
+    @property
+    def posterior(self) -> MeanStd:
+        return MeanStd(self._const_values, {})

--- a/src/mofaflex/_core/priors/horseshoe.py
+++ b/src/mofaflex/_core/priors/horseshoe.py
@@ -1,4 +1,3 @@
-import logging
 import operator
 from collections.abc import Mapping, Sequence
 from functools import reduce
@@ -18,8 +17,6 @@ from ..datasets import MofaFlexDataset
 from ..pcgse import pcgse_test
 from ..utils import MeanStd, PyroParameterDict
 from .base import Prior
-
-_logger = logging.getLogger(__name__)
 
 
 class Horseshoe(Prior):
@@ -82,7 +79,7 @@ class Horseshoe(Prior):
             self._locs[name] = PyroParam(loc)
             self._scales[name] = PyroParam(scale, constraint=constraints.softplus_positive)
 
-    def _get_prior_scale(self, name: str, **kwargs):
+    def _get_prior_scale(self, name: str, factor_plate: pyro.plate, nonfactor_plate: pyro.plate, **kwargs):
         return None
 
     def _model(
@@ -99,7 +96,9 @@ class Horseshoe(Prior):
                         f"{id}_caux_z_{name}", dist.InverseGamma(torch.full((1,), 0.5), torch.full((1,), 0.5))
                     )
                     c = torch.sqrt(caux)
-                    if (prior_scale := self._get_prior_scale(name, **kwargs)) is not None:
+                    if (
+                        prior_scale := self._get_prior_scale(name, factor_plate, nonfactor_plate, **kwargs)
+                    ) is not None:
                         c = c * prior_scale
                     local_scale = (c * local_scale) / torch.sqrt(c**2 + local_scale**2)
                 return pyro.sample(f"{id}_z_{name}", dist.Normal(torch.zeros((1,)), local_scale))
@@ -184,9 +183,16 @@ class InformedHorseshoe(Horseshoe):
         new_shape[factor_dim] = -1
         self._uninformed_scale = torch.as_tensor(self._uninformed_scale).reshape(new_shape)
 
-    def _get_prior_scale(self, name: str, hs_prior_scales: dict[str, torch.Tensor], **kwargs):
+    def _get_prior_scale(
+        self,
+        name: str,
+        factor_plate: pyro.plate,
+        nonfactor_plate: pyro.plate,
+        hs_prior_scales: Mapping[str, torch.Tensor],
+        **kwargs,
+    ):
         try:
-            return hs_prior_scales[name].reshape(self._shapes[name])
+            return self._reshape_tensor_to_batch(hs_prior_scales[name], name, factor_plate, nonfactor_plate)
         except KeyError:
             return self._uninformed_scale
 
@@ -231,11 +237,6 @@ class InformedHorseshoe(Horseshoe):
                     np.broadcast_to(one, n_factors - self._informed_factors_start_idx - self._n_informed_factors),
                 )
             )
-
-        if factor_dim < nonfactor_dim:
-            for name, prior_scale in prior_scales.items():
-                if prior_scale.shape[0] != n_factors:
-                    prior_scales[name] = prior_scale.T
 
         return {"hs_prior_scales": prior_scales}
 

--- a/src/mofaflex/_core/terms/mofaflex.py
+++ b/src/mofaflex/_core/terms/mofaflex.py
@@ -3,6 +3,7 @@ import logging
 import operator
 from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
+from contextlib import suppress
 from functools import reduce, update_wrapper
 from itertools import chain
 from typing import Any, Literal, NamedTuple
@@ -533,7 +534,8 @@ class MofaFlex(Term):
                     if nonnegative[name]:
                         res.mean[name] = self._pos_transform(res.mean[name])
                     res.mean[name] = res.mean[name].cpu().numpy().T
-                    res.std[name] = res.std[name].cpu().numpy().T
+                    with suppress(KeyError):
+                        res.std[name] = res.std[name].cpu().numpy().T
                 setattr(self, attrname, res)
 
         for prior in self._factor_priors:

--- a/src/mofaflex/_core/utils.py
+++ b/src/mofaflex/_core/utils.py
@@ -63,13 +63,11 @@ def checked_baseclass(
 
     def decorate(cls: type):
         subinitcls = cls.__dict__.get("__init_subclass__", None)
-        if subinitcls is not None:
-            subinitcls = subinitcls.__get__(cls, cls)
 
         def init_subclass(subcls, **kwargs):
             super(cls).__init_subclass__(**kwargs)
             if subinitcls is not None:
-                subinitcls(**kwargs)
+                subinitcls.__get__(subcls, subcls)(**kwargs)
             if not isabstract(subcls) and subcls.__name__[0] != "_":
                 init_sig = signature(subcls.__init__)
                 for i, (required_arg, param) in enumerate(

--- a/tests/test_mofaflex_integration.py
+++ b/tests/test_mofaflex_integration.py
@@ -262,6 +262,42 @@ def test_integration_single_var(anndata_dict, usedask):
         )
 
 
+@pytest.mark.parametrize("n_particles", [1, 5])
+@pytest.mark.parametrize("batch_size", [0, 257])
+def test_integration_constantprior(anndata_dict, tmp_path, n_particles, batch_size):
+    model = terms.MofaFlex(n_factors=5)
+    model.fit(
+        anndata_dict,
+        plot_data_overview=False,
+        max_epochs=2,
+        seed=42,
+        batch_size=batch_size,
+        n_particles=n_particles,
+        save_path=False,
+    )
+
+    factors = model.get_factors()
+    weights = model.get_weights()
+    with chdir(tmp_path):
+        model2 = terms.MofaFlex(
+            n_factors=5, factor_prior=priors.Constant(factors), weight_prior=priors.Constant(weights)
+        )
+        model2.fit(
+            anndata_dict,
+            plot_data_overview=False,
+            max_epochs=2,
+            seed=42,
+            batch_size=batch_size,
+            n_particles=n_particles,
+        )
+    factors2 = model2.get_factors()
+    weights2 = model2.get_weights()
+    for group_name, group_factors in factors.items():
+        assert np.all(group_factors == factors2[group_name])
+    for view_name, view_weights in weights.items():
+        assert np.all(view_weights == weights2[view_name])
+
+
 @pytest.mark.parametrize("usedask", [False, True])
 def test_imputation(rng, anndata_dict, usedask):
     with warnings.catch_warnings():


### PR DESCRIPTION
When used for weights, this can be used to project new data into an already existing latent space.

Closes #145