### PR TITLE
Dataloader fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning][].
 - Support for multiple additive terms.
 - Constant pseudo-prior. When used for weights, this can be used to project new data into an already existing latent space.
 - Single AnnData objects can now be used as input data. MOFA-FLEX will assume exactly one view for this type of input.
+- MuData objects with `axis=1` can now be used as input data. MOFA-FLEX will treat each modality as a group and use the `group_by`
+  argument, if given, to select a column in `.var` to split the data into views.
 
 ### Changed
 - The `show_featurenames` argument to `pl.factor` is now called `show_samplenames` to better reflect what it actually does.

--- a/src/mofaflex/_core/datasets/__init__.py
+++ b/src/mofaflex/_core/datasets/__init__.py
@@ -2,4 +2,4 @@ from .anndatadataset import AnnDataDataset
 from .anndatadictdataset import AnnDataDictDataset
 from .base import MofaFlexDataset, Preprocessor
 from .misc import CovariatesDataset, MofaFlexBatchSampler, StackDataset, merge_covariates
-from .mudatadataset import MuDataDataset
+from .mudatadataset import MuDataAxis0Dataset, MuDataAxis1Dataset

--- a/src/mofaflex/_core/datasets/anndatadataset.py
+++ b/src/mofaflex/_core/datasets/anndatadataset.py
@@ -170,29 +170,33 @@ class AnnDataDataset(MofaFlexDataset):
             "nonmissing_features": nonmissing_var,
         }
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_local_array_to_global(
         self,
         arr: NDArray[T],
         group_name: str,
         view_name: str,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ):
         return arr
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_global_array_to_local(
-        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal["samples", "features"], axis: int = 0
+        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal[0, 1], axis: int = 0
     ) -> NDArray[T]:
         return arr
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         return idx
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         return idx
 

--- a/src/mofaflex/_core/datasets/anndatadictdataset.py
+++ b/src/mofaflex/_core/datasets/anndatadictdataset.py
@@ -289,12 +289,12 @@ class AnnDataDictDataset(MofaFlexDataset):
         arr: NDArray[T],
         group_name: str,
         view_name: str,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         local_indexer: Callable[[AlignmentMap], NDArray[int]],
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ):
-        map = (self._obsmap if align_to == "samples" else self._varmap)[group_name].get(view_name)
+        map = (self._obsmap if align_to == 0 else self._varmap)[group_name].get(view_name)
         if map is None:
             return arr
 
@@ -307,12 +307,13 @@ class AnnDataDictDataset(MofaFlexDataset):
         out[map.d2g >= 0, ...] = arr[local_indexer(map), ...]
         return np.moveaxis(out, 0, axis)
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_local_array_to_global(
         self,
         arr: NDArray[T],
         group_name: str,
         view_name: str,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ):
@@ -320,27 +321,30 @@ class AnnDataDictDataset(MofaFlexDataset):
             arr, group_name, view_name, align_to, lambda map: np.argsort(map.g2d[map.g2d >= 0]), axis, fill_value
         )
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_global_array_to_local(
-        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal["samples", "features"], axis: int = 0
+        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal[0, 1], axis: int = 0
     ) -> NDArray[T]:
-        map = (self._obsmap if align_to == "samples" else self._varmap)[group_name].get(view_name)
+        map = (self._obsmap if align_to == 0 else self._varmap)[group_name].get(view_name)
         if map is None:
             return arr
         map = map.g2d
         return np.take(arr, map[map >= 0], axis=axis)
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
-        map = (self._obsmap if align_to == "samples" else self._varmap)[group_name].get(view_name)
+        map = (self._obsmap if align_to == 0 else self._varmap)[group_name].get(view_name)
         if map is None:
             return idx
         return map.g2d[map.g2d >= 0][idx]
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
-        map = (self._obsmap if align_to == "samples" else self._varmap)[group_name].get(view_name)
+        map = (self._obsmap if align_to == 0 else self._varmap)[group_name].get(view_name)
         if map is None:
             return idx
         idx = map.d2g[idx]
@@ -373,7 +377,7 @@ class AnnDataDictDataset(MofaFlexDataset):
                 else:
                     viewmissing = np.isnan(view.X).all(axis=1)
                 viewmissing = self.align_local_array_to_global(
-                    viewmissing, group_name, view_name, "samples", fill_value=True
+                    viewmissing, group_name, view_name, align_to=0, fill_value=True
                 )
                 dfs.append(
                     pd.DataFrame(

--- a/src/mofaflex/_core/datasets/base.py
+++ b/src/mofaflex/_core/datasets/base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
+from functools import wraps
+from inspect import signature
 from types import FunctionType, MethodType
 from typing import Any, Concatenate, Literal, TypeAlias, TypeVar, Union
 
@@ -106,6 +108,36 @@ class MofaFlexDataset(Dataset, ABC):
         raise NotImplementedError("Input data type not recognized.")
 
     @staticmethod
+    def _axis_arg(arg: str):
+        """Decorator that can be used by subclassses to simplfy handling of axis arguments.
+
+        The argument of the decorated method given by `arg` can take `Literal[0, 1]`. This decorator will
+        convert more user-friendly values to 0 (indicating the sample axis) or 1 (indicating the feature axis).
+
+        Args:
+            arg: The name of the axis argument.
+        """
+
+        def decorate(func: FunctionType):
+            sig = signature(func)
+
+            @wraps(func)
+            def wrapped(*args, **kwargs):
+                ba = sig.bind(*args, **kwargs)
+                axis = ba.arguments[arg]
+                if axis in ("samples", "obs"):
+                    axis = 0
+                elif axis in ("features", "var"):
+                    axis = 1
+                ba.arguments[arg] = axis
+                return func(*ba.args, **ba.kwargs)
+
+            wrapped.__annotations__[arg] = Literal[0, 1, "samples", "features", "obs", "var"]
+            return wrapped
+
+        return decorate
+
+    @staticmethod
     @abstractmethod
     def _accepts_input(data) -> bool:
         """Determines if `data` can be handled by the given Dataset.
@@ -176,8 +208,9 @@ class MofaFlexDataset(Dataset, ABC):
         """Feature names for each view."""
         pass
 
-    def get_names(self, axis: Literal[0, 1, "samples", "features"]) -> dict[str, NDArray[str]]:
-        if axis in (0, "samples"):
+    @_axis_arg("axis")
+    def get_names(self, axis: Literal[0, 1]) -> dict[str, NDArray[str]]:
+        if axis == 0:
             return self.sample_names
         else:
             return self.feature_names
@@ -228,12 +261,13 @@ class MofaFlexDataset(Dataset, ABC):
         pass
 
     @abstractmethod
+    @_axis_arg("align_to")
     def align_local_array_to_global(
         self,
         arr: NDArray[T],
         group_name: str,
         view_name: str,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ) -> NDArray[T]:
@@ -250,8 +284,9 @@ class MofaFlexDataset(Dataset, ABC):
         pass
 
     @abstractmethod
+    @_axis_arg("align_to")
     def align_global_array_to_local(
-        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal["samples", "features"], axis: int = 0
+        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal[0, 1], axis: int = 0
     ) -> NDArray[T]:
         """Align an array corresponding to global samples/features to a local samples/features by omitting observations not present in that view.
 
@@ -265,8 +300,9 @@ class MofaFlexDataset(Dataset, ABC):
         pass
 
     @abstractmethod
+    @_axis_arg("align_to")
     def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         """Map indices corresponding to local samples/features to the corresponding global indices.
 
@@ -279,8 +315,9 @@ class MofaFlexDataset(Dataset, ABC):
         pass
 
     @abstractmethod
+    @_axis_arg("align_to")
     def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         """Map indices corresponding to global samples/features to the corresponding local indices.
 
@@ -308,9 +345,10 @@ class MofaFlexDataset(Dataset, ABC):
         """
         pass
 
+    @_axis_arg("axis")
     def get_covariates(
         self,
-        axis: Literal[0, 1, "samples", "features"],
+        axis: Literal[0, 1],
         key: str | dict[str, str] | None = None,
         mkey: str | dict[str, str] | None = None,
         filter_names: str | Sequence[str] | None = None,
@@ -325,12 +363,10 @@ class MofaFlexDataset(Dataset, ABC):
             filter_names: List of groups (for `axis==0`) or views (for `axis==1`) to include. If `None`, will include all groups/views.
             fill_value: Function returning the alignment fill value (see `align_local_array_to_global`) for a given array dtype.
         """
-        if axis in (0, "samples"):
+        if axis == 0:
             names = self.group_names
-            axis = 0
         else:
             names = self.view_names
-            axis = 1
 
         if key is None:
             key = {}
@@ -347,7 +383,7 @@ class MofaFlexDataset(Dataset, ABC):
     @abstractmethod
     def _get_covariates(
         self,
-        axis: int,
+        axis: Literal[0, 1],
         key: Mapping[str, str],
         mkey: Mapping[str, str],
         filter_names: Sequence[str] | None,

--- a/src/mofaflex/_core/datasets/mudatadataset.py
+++ b/src/mofaflex/_core/datasets/mudatadataset.py
@@ -1,4 +1,5 @@
 import logging
+from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, TypeVar, Union
@@ -42,7 +43,9 @@ def _fixup_mudata(mudata: MuData, orig: MuData, with_extra: bool = True, extra_c
 
 def _mudata_to_dask(mudata: MuData, with_extra: bool = True):
     mods = {modname: anndata_to_dask(mod) for modname, mod in mudata.mod.items()}
-    dask_mudata = MuData(mods, obs=mudata.obs, var=mudata.var, obsmap=mudata.obsmap, varmap=mudata.varmap)
+    dask_mudata = MuData(
+        mods, obs=mudata.obs, var=mudata.var, obsmap=mudata.obsmap, varmap=mudata.varmap, axis=mudata.axis
+    )
     return _fixup_mudata(dask_mudata, mudata, with_extra=with_extra, extra_callback=array_to_dask)
 
 
@@ -61,6 +64,7 @@ def _select_layers(mudata: MuData, layer: Mapping[str, str | None] | None):
         var=mudata.var,
         obsmap=mudata.obsmap,
         varmap=mudata.varmap,
+        axis=mudata.axis,
     )
     return _fixup_mudata(new_mudata, mudata, with_extra=True)
 
@@ -77,206 +81,152 @@ class MuDataDataset(MofaFlexDataset):
         subset_var: str | None = "highly_variable",
         sample_names: Mapping[str, NDArray[str]] | None = None,
         feature_names: Mapping[str, NDArray[str]] | None = None,
+        groups: Mapping[str, NDArray[int]] | None = None,
         **kwargs,
     ):
-        # MuData objects with axis=1 can violate our fundamendal data model of local and global alignment:
-        # Since group assignments are taken from the global .obs, the same group may be present in multiple
-        # AnnData objects with only partially overlapping features. In this case it is not clear what the
-        # local samples and features should be.
-        if mudata.axis != 0:
-            raise ValueError("Only MuData objects with axis=0 are supported.")
-
         super().__init__(mudata, preprocessor=preprocessor, cast_to=cast_to)
         self._orig_data = _select_layers(self._data, layer)
         self._group_by = group_by
         self._sample_selection = self._feature_selection = slice(None)
         self._groups = None
-
-        if feature_names is None and subset_var is not None:
-            feature_names = {}
-            if subset_var in self._orig_data.var:
-                for modname, modmap in self._orig_data.varmap.items():
-                    feature_names[modname] = self._orig_data.mod[modname].var_names[
-                        self._orig_data.var[subset_var][modmap.reshape(-1) > 0]
-                    ]
-            else:
-                for modname, mod in self._orig_data.mod.items():
-                    if subset_var in mod.var:
-                        feature_names[modname] = mod.var_names[mod.var[subset_var]]
+        self._orig_groups = groups
 
         self.reindex_samples(sample_names)
         self.reindex_features(feature_names)
 
-    def reindex_samples(self, sample_names: Mapping[str, NDArray[str]] | None = None):
-        if sample_names is not None and (
+    def _reindex_with_groups(
+        self, attr: str, names: Mapping[str, NDArray[str]] | None = None
+    ) -> pd.Index | slice | None:
+        namesattr = f"{attr}_names"
+        if names is not None and (
             self._groups is None
             or any(
-                sample_names[group_name].size != group_idx.size
-                or np.any(sample_names[group_name] != self._data.obs_names[group_idx])
+                names[group_name].size != group_idx.size
+                or np.any(names[group_name] != getattr(self._data, namesattr)[group_idx])
                 for group_name, group_idx in self._groups.items()
-                if group_name in sample_names
+                if group_name in names
             )
         ):
-            groups = self._get_groups(self._orig_data.obs)
+            groups = (
+                self._get_groups(getattr(self._orig_data, attr)) if self._orig_groups is None else self._orig_groups
+            )
             selection = pd.Index(())
             for group_name, group_idx in groups.items():
-                group_sample_names = sample_names.get(group_name)
-                if group_sample_names is not None:
-                    group_sample_names = pd.Index(group_sample_names)
-                    if np.any(~group_sample_names.isin(self._orig_data.obs_names[group_idx])):
+                group_names = names.get(group_name)
+                if group_names is not None:
+                    group_names = pd.Index(group_names)
+                    if np.any(~group_names.isin(getattr(self._orig_data, namesattr)[group_idx])):
                         _logger.warning(
-                            f"Not all sample names given for group {group_name} are present in the data. Restricting alignment to group names present in the data."
+                            f"Not all names given for group {group_name} are present in the data. Restricting alignment to group names present in the data."
                         )
-                        group_sample_names = group_sample_names.intersection(self._orig_data.obs_names[group_idx])
+                        group_names = group_names.intersection(getattr(self._orig_data, namesattr)[group_idx])
                 else:
-                    group_sample_names = self._orig_data.obs_names[group_idx]
-                selection = selection.append(group_sample_names)
-            self._data = self._orig_data[selection, self._feature_selection]
-            self._sample_selection = selection
-        elif sample_names is None:
-            self._data = self._orig_data[:, self._feature_selection]
-            self._sample_selection = slice(None)
+                    group_names = getattr(self._orig_data, namesattr)[group_idx]
+                selection = selection.append(group_names)
+        elif names is None:
+            selection = slice(None)
+        else:
+            selection = None
 
-        self._groups = self._get_groups(self._data.obs)
+        return selection
 
+    def _calc_groups(self, attr: str):
+        mapattr = f"{attr}map"
+
+        self._groups = self._get_groups(getattr(self._data, attr))
         self._needs_alignment = {}
         for group_name, group_idx in self._groups.items():
             gneeds_align = set()
-            for view_name, obsmap in self._data.obsmap.items():
-                obsmap = obsmap[group_idx]
-                if np.any(obsmap == 0) or np.any(np.diff(obsmap) != 1):
-                    gneeds_align.add(view_name)
+            for name, map in getattr(self._data, mapattr).items():
+                map = map[group_idx]
+                if np.any(map == 0) or np.any(np.diff(map) != 1):
+                    gneeds_align.add(name)
             self._needs_alignment[group_name] = gneeds_align
 
-    def _get_groups(self, df):
+    def _get_groups(self, df: pd.DataFrame, group_by: str | None = None):
+        if group_by is None:
+            group_by = self._group_by
         return df.groupby(
-            pd.Categorical(df[self._group_by]).rename_categories(lambda x: str(x))
-            if self._group_by is not None
-            else lambda x: "group_1",
+            pd.Categorical(df[group_by]).rename_categories(lambda x: str(x))
+            if group_by is not None
+            else lambda x: self._dummy_group,
             observed=True,
         ).indices
 
-    def reindex_features(self, feature_names: Mapping[str, NDArray[str]] | None = None):
-        if feature_names is not None and any(
-            feature_names[view_name].size != fnames.size or np.any(feature_names[view_name] != fnames)
-            for view_name, fnames in self.feature_names.items()
-            if view_name in feature_names
+    def _reindex(
+        self, attr: str, axisattr: str, names: Mapping[str, NDArray[str]] | None = None
+    ) -> pd.Index | slice | None:
+        namesattr = f"{attr}_names"
+
+        if names is not None and any(
+            names[name].size != cnames.size or np.any(names[name] != cnames)
+            for name, cnames in getattr(self, f"{axisattr}_names").items()
+            if name in names
         ):
             selection = pd.Index(())
             for modname, mod in self._orig_data.mod.items():
-                view_feature_names = feature_names.get(modname)
-                if view_feature_names is not None:
-                    view_feature_names = pd.Index(view_feature_names)
-                    if np.any(~view_feature_names.isin(mod.var_names)):
+                cnames = names.get(modname)
+                if cnames is not None:
+                    cnames = pd.Index(cnames)
+                    if np.any(~cnames.isin(getattr(mod, namesattr))):
                         _logger.warning(
-                            f"Not all feature names given for view {modname} are present in the data. Restricting alignment to feature names present in the data."
+                            f"Not all names given for modality {modname} are present in the data. Restricting alignment to names present in the data."
                         )
-                        view_feature_names = view_feature_names.intersection(mod.var_names)
+                        cnames = cnames.intersection(getattr(mod, namesattr))
                 else:
-                    view_feature_names = mod.var_names
-                selection = selection.append(view_feature_names)
-            self._data = self._orig_data[self._sample_selection, selection]
-            self._feature_selection = selection
-        elif feature_names is None:
-            self._data = self._orig_data[self._sample_selection, :]
-            self._feature_selection = slice(None)
+                    cnames = getattr(mod, namesattr)
+                selection = selection.append(cnames)
+        elif names is None:
+            selection = slice(None)
+        else:
+            selection = None
 
-    @staticmethod
-    def _accepts_input(data):
-        return isinstance(data, MuData)
-
-    @property
-    def n_features(self) -> dict[str, int]:
-        return {modname: mod.n_vars for modname, mod in self._data.mod.items()}
-
-    @property
-    def n_samples(self) -> dict[str, int]:
-        return {groupname: len(groupidx) for groupname, groupidx in self._groups.items()}
+        return selection
 
     @property
     def n_samples_total(self) -> int:
         return self._data.n_obs
 
     @property
-    def view_names(self) -> NDArray[str]:
-        return np.asarray(tuple(self._data.mod.keys()))
+    def n_features_total(self) -> int:
+        return self._data.n_vars
 
     @property
-    def group_names(self) -> NDArray[str]:
-        return np.asarray(tuple(self._groups.keys()))
+    @abstractmethod
+    def _subset_reorder(self):
+        pass
+        return slice(None) if self._data.axis == 0 else slice(None, None, -1)
 
-    @property
-    def sample_names(self) -> dict[str, NDArray[str]]:
-        return {groupname: self._data.obs_names[groupidx].to_numpy() for groupname, groupidx in self._groups.items()}
-
-    @property
-    def feature_names(self) -> dict[str, NDArray[str]]:
-        return {viewname: mod.var_names.to_numpy() for viewname, mod in self._data.mod.items()}
-
-    def __getitems__(self, idx: Mapping[str, int | Sequence[int]]) -> dict[str, dict]:
-        data = {}
-        nonmissing_obs = {}
-        nonmissing_var = {}
-        for group_name, group_idx in idx.items():
-            group = {}
-            gnonmissing_obs = {}
-            gnonmissing_var = {}
-            glabel = self._groups[group_name][group_idx]
-            subdata = self._data[glabel, :]
-            for modname, mod in subdata.mod.items():
-                cnonmissing_obs = (
-                    np.nonzero(subdata.obsmap[modname] > 0)[0]
-                    if modname in self._needs_alignment[group_name]
-                    else slice(None)
-                )
-                arr, gnonmissing_obs[modname], gnonmissing_var[modname] = self.preprocessor(
-                    mod.X, cnonmissing_obs, slice(None), group_name, modname
-                )
-                if self.cast_to is not None:
-                    arr = arr.astype(self.cast_to, copy=False)
-                if sparse.issparse(arr):
-                    arr = arr.toarray()
-                group[modname] = np.asarray(
-                    arr
-                )  # arr may be an anndata._core.views.ArrayView, which is not recognized by PyTorch
-            data[group_name] = group
-            idx[group_name] = np.asarray(group_idx)
-            nonmissing_obs[group_name] = gnonmissing_obs
-            nonmissing_var[group_name] = gnonmissing_var
-        return {
-            "data": data,
-            "sample_idx": idx,
-            "nonmissing_samples": nonmissing_obs,
-            "nonmissing_features": nonmissing_var,
-        }
-
-    def _align_local_array_to_global(
+    def _align_local_array_to_global_impl(
         self,
         arr: NDArray[T],
-        view_name: str,
-        subdata: MuData | None = None,
-        group_name: str | None = None,
-        align_to: Literal["samples", "features"] = "samples",
-        axis: int = 0,
-        fill_value: np.ScalarType = np.nan,
+        name1: str | None,
+        name2: str,
+        subdata: MuData | None,
+        align_to: Literal["samples", "features"],
+        axis: int,
+        fill_value: np.ScalarType,
+        attr: str,
+        align_axis: int,
+        param: str,
     ) -> NDArray[T]:
-        if align_to == "features":
+        if self._data.axis == 0 and align_to == "features" or self._data.axis == 1 and align_to == "samples":
             return arr
 
         if subdata is None:
-            if group_name is None:
-                raise ValueError("Need either subdata or group_name, but both are None.")
-            if view_name not in self._needs_alignment[group_name]:
+            if name1 is None:
+                raise ValueError(f"Need either subdata or {param}, but both are None.")
+            if name2 not in self._needs_alignment[name1]:
                 return arr
-            subdata = self._data[self._groups[group_name], :]
+            subdata = self._data[(self._groups[name1], slice(None))[self._subset_reorder]]
 
-        viewidx = subdata.obsmap[view_name]
-        nnz = viewidx > 0
+        idx = getattr(subdata, f"{attr}map")[name2]
+        nnz = idx > 0
 
-        outshape = [subdata.n_obs] + list(arr.shape[:axis]) + list(arr.shape[axis + 1 :])
+        outshape = [subdata.shape[align_axis]] + list(arr.shape[:axis]) + list(arr.shape[axis + 1 :])
 
         out = np.full(outshape, fill_value=fill_value, dtype=np.promote_types(type(fill_value), arr.dtype), order="C")
-        out[nnz, ...] = np.moveaxis(arr, axis, 0)[viewidx[nnz] - 1, ...]
+        out[nnz, ...] = np.moveaxis(arr, axis, 0)[idx[nnz] - 1, ...]
         return np.moveaxis(out, 0, axis)
 
     def align_local_array_to_global(
@@ -295,37 +245,37 @@ class MuDataDataset(MofaFlexDataset):
     def align_global_array_to_local(
         self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal["samples", "features"], axis: int = 0
     ) -> NDArray[T]:
-        if align_to == "samples":
+        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
             idx = self.map_local_indices_to_global(slice(None), group_name, view_name, align_to)
             return np.take(arr, idx, axis=axis)
         else:
             return arr
 
-    def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    def _map_local_indices_to_global(
+        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal["samples, features"], attr: str, axis: int
     ) -> NDArray[int]:
-        if align_to == "samples":
-            subdata = self._data[self._groups[group_name], :]
-            map = subdata.obsmap[view_name]
+        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
+            subdata = self._data[(self._groups[name1], slice(None))[self._subset_reorder]]
+            map = getattr(subdata, f"{attr}map")[name2]
             mask = map > 0
-            n = subdata.mod[view_name].n_obs
-            viewidx = np.empty(n, dtype=map.dtype)
-            viewidx[map[mask] - 1] = np.arange(n, dtype=map.dtype) + np.cumsum(~mask)[mask]
+            n = subdata.mod[name2].shape[axis]
+            _idx = np.empty(n, dtype=map.dtype)
+            _idx[map[mask] - 1] = np.arange(n, dtype=map.dtype) + np.cumsum(~mask)[mask]
 
-            return viewidx[idx]
+            return _idx[idx]
         else:
             return idx
 
-    def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    def _map_global_indices_to_local(
+        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal["samples, features"], attr: str
     ) -> NDArray[int]:
-        if align_to == "samples":
-            subdata = self._data[self._groups[group_name], :]
-            return subdata.obsmap[view_name][idx].astype(int) - 1
+        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
+            subdata = self._data[(self._groups[name1], slice(None))[self._subset_reorder]]
+            return getattr(subdata, f"{attr}map")[name2][idx].astype(int) - 1
         else:
             return idx
 
-    def get_obs(self) -> dict[str, pd.DataFrame]:
+    def _push_obs(self) -> MuData:
         # We don't want to duplicate MuData's push_obs logic, but at the same time
         # we don't want to modify the data object. So we create a temporary fake
         # MuData object with the same metadata, but no actual data
@@ -335,35 +285,33 @@ class MuDataDataset(MofaFlexDataset):
         }
 
         # need to pass obs in the constructor to make shape validation for obsmap work
-        fakemudata = MuData(fakeadatas, obs=self._data.obs, obsmap=self._data.obsmap)
+        fakemudata = MuData(fakeadatas, obs=self._data.obs, obsmap=self._data.obsmap, axis=self._data.axis)
         # need to replace obs since the constructor runs update(), which breaks push_obs()
         fakemudata.obs = self._data.obs
         fakemudata.push_obs()
-        return {
-            group_name: {
-                modname: mod.obs.reindex(self._data[group_idx, :].obs_names, fill_value=pd.NA).apply(
-                    lambda x: x.astype("string") if x.dtype == "O" else x, axis=1
-                )
-                for modname, mod in fakemudata.mod.items()
-            }
-            for group_name, group_idx in self._groups.items()
-        }
+        return fakemudata
 
     def get_missing_obs(self) -> pd.DataFrame:
         dfs = []
-        for group_name, group_idx in self._groups.items():
-            subdata = self._data[group_idx, :]
+        for _group_name, group_idx in self._groups.items():
+            subdata = self._data[(group_idx, slice(None))[self._subset_reorder]]
             for modname, mod in subdata.mod.items():
+                group_name, view_name = (_group_name, modname)[self._subset_reorder]
                 if sparse.issparse(mod.X):
                     modmissing = mod.X.copy()
                     modmissing.data = np.isnan(modmissing.data)
                     modmissing = np.asarray(modmissing.sum(axis=1)).squeeze() == modmissing.shape[1]
                 else:
                     modmissing = np.isnan(mod.X).all(axis=1)
-                modmissing = self._align_local_array_to_global(modmissing, modname, subdata, fill_value=True)
+                modmissing = self._align_local_array_to_global(modmissing, view_name, subdata, fill_value=True)
                 dfs.append(
                     pd.DataFrame(
-                        {"view": modname, "group": group_name, "obs_name": subdata.obs_names, "missing": modmissing}
+                        {
+                            "view": view_name,
+                            "group": group_name,
+                            "obs_name": self.sample_names[group_name],
+                            "missing": modmissing,
+                        }
                     )
                 )
         return pd.concat(dfs, axis=0, ignore_index=True)
@@ -384,19 +332,19 @@ class MuDataDataset(MofaFlexDataset):
             dict_reorder = slice(None, None, -1)
         attrm = f"{attr}m"
         attrnames = f"{attr}_names"
-        outer_msg, inner_msg = ("group", "view")[dict_reorder]
+        outer_msg, inner_msg = ("group", "view")[dict_reorder][self._subset_reorder]
 
         covariates = defaultdict(dict)
         covar_dims = defaultdict(set)
         for group_name, group_idx in self._groups.items():
-            if axis == 0 and filter_names is not None and group_name not in filter_names:
+            if self._data.axis == axis and filter_names is not None and group_name not in filter_names:
                 continue
-            for modname in self.view_names:
-                if axis == 1 and filter_names is not None and modname not in filter_names:
+            for modname in self._data.mod.keys():
+                if self._data.axis == axis and filter_names is not None and modname not in filter_names:
                     continue
-                subdata = self._data[group_idx, self.feature_names[modname]]
+                subdata = self._data[(group_idx, self.get_names(1 - self._data.axis)[modname])[self._subset_reorder]]
                 mod = subdata.mod[modname]
-                outer_key, inner_key = (group_name, modname)[dict_reorder]
+                outer_key, inner_key = (group_name, modname)[dict_reorder][self._subset_reorder]
 
                 ckey = key.get(outer_key, None)
                 cmkey = mkey.get(outer_key, None)
@@ -461,26 +409,273 @@ class MuDataDataset(MofaFlexDataset):
                 warn_dask(_logger)
         return data
 
-    def _apply_to_view(
-        self, view_name: str, func: ApplyToCallable[T], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    def _apply_to_axis_complement(
+        self, name: str, func: ApplyToCallable[T], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
     ) -> dict[str, T]:
         data = self._data_for_apply()
         ret = {}
         for group_name, group_idx in self._groups.items():
-            cret = func(data[group_idx, :][view_name], group_name, **kwargs, **gkwargs[group_name])
+            cret = func(
+                data[(group_idx, slice(None))[self._subset_reorder]][name], group_name, **kwargs, **gkwargs[group_name]
+            )
+            ret[name] = apply_to_nested(cret, from_dask)
+        return ret
+
+    def _apply_to_axis(
+        self, name: str, func: ApplyToCallable[T], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        data = self._data_for_apply()
+        ret = {}
+        data = data[(self._groups[name], slice(None))[self._subset_reorder]]
+        for modname, mod in data.mod.items():
+            cret = func(mod, modname, **kwargs, **gkwargs[modname])
+            ret[modname] = apply_to_nested(cret, from_dask)
+        return ret
+
+    def _apply_by_axis_complement(
+        self,
+        func: ApplyCallable[T],
+        names: Sequence[str],
+        attr: str,
+        gkwargs: Mapping[str, Mapping[str, Any]],
+        **kwargs,
+    ) -> dict[str, T]:
+        data = self._data
+        if (
+            not isinstance(self._sample_selection, slice)
+            or self._sample_selection != slice(None)
+            or not isinstance(self._feature_selection, slice)
+            or self._feature_selection != slice(None)
+        ) and settings.use_dask:
+            if have_dask():
+                data = _mudata_to_dask(self._orig_data, with_extra=False)[
+                    self._sample_selection, self._feature_selection
+                ]
+            else:
+                warn_dask(_logger)
+        ret = {}
+        attrmap = getattr(self._data, f"{attr}map")
+        for modname in names:
+            mod = data.mod[modname]
+            groups = np.empty((mod.shape[self._data.axis],), dtype="O")
+            for group, group_idx in self._groups.items():
+                modidx = attrmap[modname][group_idx]
+                modidx = modidx[modidx > 0] - 1
+                groups[modidx] = group
+
+            cret = func(mod, *(groups, modname)[self._subset_reorder], **kwargs, **gkwargs[modname])
+            ret[modname] = apply_to_nested(cret, from_dask)
+        return ret
+
+    def _apply_by_axis(
+        self,
+        func: ApplyCallable[T],
+        names: Sequence[str],
+        attr: str,
+        namesattr: str,
+        gkwargs: Mapping[str, Mapping[str, Any]],
+        **kwargs,
+    ) -> dict[str, T]:
+        data = self._data_for_apply()
+        ret = {}
+        for group_name in names:
+            group_idx = self._groups[group_name]
+            subdata = data[(group_idx, slice(None))[self._subset_reorder]]
+            gdata = {}
+            convert = False
+            for modname, mod in subdata.mod.items():
+                if mod.shape[subdata.axis] != subdata.shape[subdata.axis]:
+                    convert = True
+                gdata[modname] = mod
+            if convert:
+                for modname, mod in gdata.items():
+                    mod = mod.copy()
+                    mod.X = mod.X.astype(np.promote_types(mod.X.dtype, type(np.nan)))
+                    gdata[modname] = mod
+            gdata = ad.concat(
+                gdata,
+                axis=1 - subdata.axis,
+                join="outer",
+                label="____concat",
+                merge="unique",
+                uns_merge=None,
+                fill_value=np.nan,
+            )
+            if (getattr(gdata, namesattr) != getattr(subdata, namesattr)).any():
+                gdata = gdata[(getattr(subdata, namesattr), slice(None))[self._subset_reorder]]
+            cret = func(
+                gdata,
+                *(group_name, getattr(gdata, attr)["____concat"].to_numpy())[self._subset_reorder],
+                **kwargs,
+                **gkwargs[group_name],
+            )
             ret[group_name] = apply_to_nested(cret, from_dask)
         return ret
+
+
+class MuDataAxis0Dataset(MuDataDataset):
+    _dummy_group = "group_1"
+
+    def __init__(
+        self,
+        mudata: MuData,
+        *,
+        layer: Mapping[str, str | None] | str | None = None,
+        group_by: str | Sequence[str] | None = None,
+        preprocessor: Preprocessor | None = None,
+        cast_to: np.number | None = np.float32,
+        subset_var: str | None = "highly_variable",
+        sample_names: Mapping[str, NDArray[str]] | None = None,
+        feature_names: Mapping[str, NDArray[str]] | None = None,
+        **kwargs,
+    ):
+        if feature_names is None and subset_var is not None:
+            feature_names = {}
+            if subset_var in mudata.var:
+                for modname, modmap in mudata.varmap.items():
+                    feature_names[modname] = mudata.mod[modname].var_names[mudata.var[subset_var][modmap.ravel() > 0]]
+            else:
+                for modname, mod in mudata.mod.items():
+                    if subset_var in mod.var:
+                        feature_names[modname] = mod.var_names[mod.var[subset_var]]
+        super().__init__(
+            mudata,
+            layer=layer,
+            group_by=group_by,
+            preprocessor=preprocessor,
+            cast_to=cast_to,
+            subset_var=subset_var,
+            sample_names=sample_names,
+            feature_names=feature_names,
+        )
+
+    def reindex_samples(self, sample_names: Mapping[str, NDArray[str]] | None = None):
+        selection = self._reindex_with_groups("obs", sample_names)
+        if selection is not None:
+            self._data = self._orig_data[selection, self._feature_selection]
+            self._sample_selection = selection
+        self._calc_groups("obs")
+
+    def reindex_features(self, feature_names: Mapping[str, NDArray[str]] | None = None):
+        selection = self._reindex("var", "feature", feature_names)
+        if selection is not None:
+            self._data = self._orig_data[self._sample_selection, selection]
+            self._feature_selection = selection
+
+    @staticmethod
+    def _accepts_input(data):
+        return isinstance(data, MuData) and data.axis == 0
+
+    @property
+    def _subset_reorder(self):
+        return slice(None)
+
+    @property
+    def n_features(self) -> dict[str, int]:
+        return {modname: mod.n_vars for modname, mod in self._data.mod.items()}
+
+    @property
+    def n_samples(self) -> dict[str, int]:
+        return {groupname: len(groupidx) for groupname, groupidx in self._groups.items()}
+
+    @property
+    def view_names(self) -> NDArray[str]:
+        return np.asarray(tuple(self._data.mod.keys()))
+
+    @property
+    def group_names(self) -> NDArray[str]:
+        return np.asarray(tuple(self._groups.keys()))
+
+    @property
+    def sample_names(self) -> dict[str, NDArray[str]]:
+        return {groupname: self._data.obs_names[groupidx].to_numpy() for groupname, groupidx in self._groups.items()}
+
+    @property
+    def feature_names(self) -> dict[str, NDArray[str]]:
+        return {viewname: mod.var_names.to_numpy() for viewname, mod in self._data.mod.items()}
+
+    def __getitems__(self, idx: Mapping[str, int | Sequence[int]]) -> dict[str, dict]:
+        data = {}
+        nonmissing_obs = {}
+        nonmissing_var = {}
+        for group_name, group_idx in idx.items():
+            group = {}
+            gnonmissing_obs = {}
+            gnonmissing_var = {}
+            glabel = self._groups[group_name][group_idx]
+            subdata = self._data[glabel, :]
+            for modname, mod in subdata.mod.items():
+                cnonmissing_obs = (
+                    np.nonzero(subdata.obsmap[modname] > 0)[0]
+                    if modname in self._needs_alignment[group_name]
+                    else slice(None)
+                )
+                arr, gnonmissing_obs[modname], gnonmissing_var[modname] = self.preprocessor(
+                    mod.X, cnonmissing_obs, slice(None), group_name, modname
+                )
+                if self.cast_to is not None:
+                    arr = arr.astype(self.cast_to, copy=False)
+                if sparse.issparse(arr):
+                    arr = arr.toarray()
+                group[modname] = np.asarray(
+                    arr
+                )  # arr may be an anndata._core.views.ArrayView, which is not recognized by PyTorch
+            data[group_name] = group
+            idx[group_name] = np.asarray(group_idx)
+            nonmissing_obs[group_name] = gnonmissing_obs
+            nonmissing_var[group_name] = gnonmissing_var
+        return {
+            "data": data,
+            "sample_idx": idx,
+            "nonmissing_samples": nonmissing_obs,
+            "nonmissing_features": nonmissing_var,
+        }
+
+    def _align_local_array_to_global(
+        self,
+        arr: NDArray[T],
+        view_name: str,
+        subdata: MuData | None = None,
+        group_name: str | None = None,
+        align_to: Literal["samples", "features"] = "samples",
+        axis: int = 0,
+        fill_value: np.ScalarType = np.nan,
+    ) -> NDArray[T]:
+        return self._align_local_array_to_global_impl(
+            arr, group_name, view_name, subdata, align_to, axis, fill_value, "obs", 0, "group_name"
+        )
+
+    def map_local_indices_to_global(
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    ) -> NDArray[int]:
+        return self._map_local_indices_to_global(idx, group_name, view_name, align_to, "obs", 0)
+
+    def map_global_indices_to_local(
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    ) -> NDArray[int]:
+        return self._map_global_indices_to_local(idx, group_name, view_name, align_to, "obs")
+
+    def get_obs(self) -> dict[str, pd.DataFrame]:
+        fakemudata = self._push_obs()
+        return {
+            group_name: {
+                modname: mod.obs.reindex(self._data[group_idx, :].obs_names, fill_value=pd.NA).apply(
+                    lambda x: x.astype("string") if x.dtype == "O" else x, axis=1
+                )
+                for modname, mod in fakemudata.mod.items()
+            }
+            for group_name, group_idx in self._groups.items()
+        }
+
+    def _apply_to_view(
+        self, view_name: str, func: ApplyToCallable[T], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        return self._apply_to_axis_complement(view_name, func, gkwargs, **kwargs)
 
     def _apply_to_group(
         self, group_name: str, func: ApplyToCallable[T], vkwargs: Mapping[str, Mapping[str, Any]], **kwargs
     ) -> dict[str, T]:
-        data = self._data_for_apply()
-        ret = {}
-        data = data[self._groups[group_name], :]
-        for modname, mod in data.mod.items():
-            cret = func(mod, modname, **kwargs, **vkwargs[modname])
-            ret[modname] = apply_to_nested(cret, from_dask)
-        return ret
+        return self._apply_to_axis(group_name, func, vkwargs, **kwargs)
 
     def _apply_by_group_view(
         self,
@@ -505,56 +700,214 @@ class MuDataDataset(MofaFlexDataset):
     def _apply_by_view(
         self, func: ApplyCallable[T], view_names: Sequence[str], vkwargs: Mapping[str, Mapping[str, Any]], **kwargs
     ) -> dict[str, T]:
-        data = self._data
-        if (
-            not isinstance(self._sample_selection, slice)
-            or self._sample_selection != slice(None)
-            or not isinstance(self._feature_selection, slice)
-            or self._feature_selection != slice(None)
-        ) and settings.use_dask:
-            if have_dask():
-                data = _mudata_to_dask(self._orig_data, with_extra=False)[
-                    self._sample_selection, self._feature_selection
-                ]
-            else:
-                warn_dask(_logger)
-        ret = {}
-        for modname in view_names:
-            mod = data.mod[modname]
-            groups = np.empty((mod.n_obs,), dtype="O")
-            for group, group_idx in self._groups.items():
-                modidx = self._data.obsmap[modname][group_idx]
-                modidx = modidx[modidx > 0] - 1
-                groups[modidx] = group
-
-            cret = func(mod, groups, modname, **kwargs, **vkwargs[modname])
-            ret[modname] = apply_to_nested(cret, from_dask)
-        return ret
+        return self._apply_by_axis_complement(func, view_names, "obs", vkwargs, **kwargs)
 
     def _apply_by_group(
         self, func: ApplyCallable[T], group_names: Sequence[str], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
     ) -> dict[str, T]:
+        return self._apply_by_axis(func, group_names, "var", "obs_names", gkwargs, **kwargs)
+
+
+class MuDataAxis1Dataset(MuDataDataset):
+    _dummy_group = "view_1"
+
+    def __init__(
+        self,
+        mudata: MuData,
+        *,
+        layer: Mapping[str, str | None] | str | None = None,
+        group_by: str | Sequence[str] | None = None,
+        preprocessor: Preprocessor | None = None,
+        cast_to: np.number | None = np.float32,
+        subset_var: str | None = "highly_variable",
+        sample_names: Mapping[str, NDArray[str]] | None = None,
+        feature_names: Mapping[str, NDArray[str]] | None = None,
+        **kwargs,
+    ):
+        if feature_names is None and subset_var is not None:
+            feature_names = {}
+            groups = self._get_groups(mudata.var, group_by)
+            if subset_var in mudata.var:
+                for view_name, view_idx in groups.items():
+                    names = mudata.var[subset_var][view_idx]
+                    feature_names[view_name] = names.index[names]
+            else:
+                for modname, mod in mudata.mod.items():
+                    modmap = mudata.varmap[modname].ravel()
+                    modmask = modmap > 0
+                    if subset_var in mod.var:
+                        for view_name, view_idx in groups.items():
+                            cmask = np.zeros_like(modmask)
+                            cmask[view_idx] = 1
+                            cmask &= modmask
+                            cnames = mod.var[subset_var][modmap[cmask] - 1]
+                            cnames = cnames.index[cnames]
+                            if view_name not in feature_names:
+                                feature_names[view_name] = cnames
+                            else:
+                                feature_names[view_name] = feature_names[view_name].intersection(cnames)
+        else:
+            groups = None
+        super().__init__(
+            mudata,
+            layer=layer,
+            group_by=group_by,
+            preprocessor=preprocessor,
+            cast_to=cast_to,
+            subset_var=subset_var,
+            sample_names=sample_names,
+            feature_names=feature_names,
+            groups=groups,
+        )
+
+    def reindex_samples(self, sample_names: Mapping[str, NDArray[str]] | None = None):
+        selection = self._reindex("obs", "sample", sample_names)
+        if selection is not None:
+            self._data = self._orig_data[selection, self._feature_selection]
+            self._sample_selection = selection
+
+    def reindex_features(self, feature_names: Mapping[str, NDArray[str]] | None = None):
+        selection = self._reindex_with_groups("var", feature_names)
+        if selection is not None:
+            self._data = self._orig_data[self._sample_selection, selection]
+            self._feature_selection = selection
+        self._calc_groups("var")
+        self._nonmissing_var = {}
+        for view_name, view_idx in self._groups.items():
+            vnonmissing_var = {}
+            for modname in self._needs_alignment[view_name]:
+                vnonmissing_var[modname] = np.nonzero(self._data.varmap[modname][view_idx] > 0)[0]
+            self._nonmissing_var[view_name] = vnonmissing_var
+
+    @staticmethod
+    def _accepts_input(data):
+        return isinstance(data, MuData) and data.axis == 1
+
+    @property
+    def _subset_reorder(self):
+        return slice(None, None, -1)
+
+    @property
+    def n_samples(self) -> dict[str, int]:
+        return {modname: mod.n_obs for modname, mod in self._data.mod.items()}
+
+    @property
+    def n_features(self) -> dict[str, int]:
+        return {viewname: len(groupidx) for viewname, groupidx in self._groups.items()}
+
+    @property
+    def group_names(self) -> NDArray[str]:
+        return np.asarray(tuple(self._data.mod.keys()))
+
+    @property
+    def view_names(self) -> NDArray[str]:
+        return np.asarray(tuple(self._groups.keys()))
+
+    @property
+    def feature_names(self) -> dict[str, NDArray[str]]:
+        return {viewname: self._data.var_names[groupidx].to_numpy() for viewname, groupidx in self._groups.items()}
+
+    @property
+    def sample_names(self) -> dict[str, NDArray[str]]:
+        return {groupname: mod.obs_names.to_numpy() for groupname, mod in self._data.mod.items()}
+
+    def __getitems__(self, idx: Mapping[str, int | Sequence[int]]) -> dict[str, dict]:
+        data = {}
+        nonmissing_obs = {}
+        nonmissing_var = {}
+        for group_name, group_idx in idx.items():
+            group = {}
+            gnonmissing_obs = {}
+            gnonmissing_var = {}
+            for view_name, view_idx in self._groups.items():
+                cnonmissing_var = self._nonmissing_var[view_name].get(group_name, slice(None))
+                arr, gnonmissing_obs[view_name], gnonmissing_var[view_name] = self.preprocessor(
+                    self._data[:, view_idx][group_name].X[group_idx, :],
+                    slice(None),
+                    cnonmissing_var,
+                    group_name,
+                    view_name,
+                )
+                if self.cast_to is not None:
+                    arr = arr.astype(self.cast_to, copy=False)
+                if sparse.issparse(arr):
+                    arr = arr.toarray()
+                group[view_name] = np.asarray(
+                    arr
+                )  # arr may be an anndata._core.views.ArrayView, which is not recognized by PyTorch
+            data[group_name] = group
+            idx[group_name] = np.asarray(group_idx)
+            nonmissing_obs[group_name] = gnonmissing_obs
+            nonmissing_var[group_name] = gnonmissing_var
+        return {
+            "data": data,
+            "sample_idx": idx,
+            "nonmissing_samples": nonmissing_obs,
+            "nonmissing_features": nonmissing_var,
+        }
+
+    def _align_local_array_to_global(
+        self,
+        arr: NDArray[T],
+        view_name: str,
+        subdata: MuData | None = None,
+        group_name: str | None = None,
+        align_to: Literal["samples", "features"] = "samples",
+        axis: int = 0,
+        fill_value: np.ScalarType = np.nan,
+    ) -> NDArray[T]:
+        return self._align_local_array_to_global_impl(
+            arr, view_name, group_name, subdata, align_to, axis, fill_value, "var", 1, "view_name"
+        )
+
+    def map_local_indices_to_global(
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    ) -> NDArray[int]:
+        return self._map_local_indices_to_global(idx, view_name, group_name, align_to, "var", 1)
+
+    def map_global_indices_to_local(
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+    ) -> NDArray[int]:
+        return self._map_global_indices_to_local(idx, view_name, group_name, align_to, "var")
+
+    def get_obs(self) -> dict[str, pd.DataFrame]:
+        fakemudata = self._push_obs()
+        return {modname: dict.fromkeys(self._groups.keys(), mod.obs) for modname, mod in fakemudata.mod.items()}
+
+    def _apply_to_view(
+        self, view_name: str, func: ApplyToCallable[T], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        return self._apply_to_axis(view_name, func, gkwargs, **kwargs)
+
+    def _apply_to_group(
+        self, group_name: str, func: ApplyToCallable[T], vkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        return self._apply_to_axis_complement(group_name, func, vkwargs, **kwargs)
+
+    def _apply_by_group_view(
+        self,
+        func: ApplyCallable[T],
+        group_names: Sequence[str],
+        view_names: Sequence[str],
+        gvkwargs: Mapping[str, Mapping[str, Mapping[str, Any]]],
+        **kwargs,
+    ) -> dict[str, dict[str, T]]:
         data = self._data_for_apply()
         ret = {}
-        for group_name in group_names:
-            group_idx = self._groups[group_name]
-            subdata = data[group_idx, :]
-            gdata = {}
-            convert = False
-            for modname, mod in subdata.mod.items():
-                if mod.n_obs != subdata.n_obs:
-                    convert = True
-                gdata[modname] = mod
-            if convert:
-                for modname, mod in gdata.items():
-                    mod = mod.copy()
-                    mod.X = mod.X.astype(np.promote_types(mod.X.dtype, type(np.nan)))
-                    gdata[modname] = mod
-            gdata = ad.concat(
-                gdata, axis="var", join="outer", label="__view", merge="unique", uns_merge=None, fill_value=np.nan
-            )
-            if (gdata.obs_names != subdata.obs_names).any():
-                gdata = gdata[subdata.obs_names, :]
-            cret = func(gdata, group_name, gdata.var["__view"].to_numpy(), **kwargs, **gkwargs[group_name])
-            ret[group_name] = apply_to_nested(cret, from_dask)
+        for view_name in view_names:
+            view_idx = self._groups[view_name]
+            subdata = data[:, view_idx]
+            for modname in group_names:
+                ccret = func(subdata.mod[modname], modname, view_name, **kwargs, **gvkwargs[modname][view_name])
+                ret.get(modname, {})[view_name] = ccret
         return ret
+
+    def _apply_by_view(
+        self, func: ApplyCallable[T], view_names: Sequence[str], vkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        return self._apply_by_axis(func, view_names, "obs", "var_names", vkwargs, **kwargs)
+
+    def _apply_by_group(
+        self, func: ApplyCallable[T], group_names: Sequence[str], gkwargs: Mapping[str, Mapping[str, Any]], **kwargs
+    ) -> dict[str, T]:
+        return self._apply_by_axis_complement(func, group_names, "var", gkwargs, **kwargs)

--- a/src/mofaflex/_core/datasets/mudatadataset.py
+++ b/src/mofaflex/_core/datasets/mudatadataset.py
@@ -203,14 +203,13 @@ class MuDataDataset(MofaFlexDataset):
         name1: str | None,
         name2: str,
         subdata: MuData | None,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         axis: int,
         fill_value: np.ScalarType,
         attr: str,
-        align_axis: int,
         param: str,
     ) -> NDArray[T]:
-        if self._data.axis == 0 and align_to == "features" or self._data.axis == 1 and align_to == "samples":
+        if self._data.axis == 1 - align_to:
             return arr
 
         if subdata is None:
@@ -223,18 +222,19 @@ class MuDataDataset(MofaFlexDataset):
         idx = getattr(subdata, f"{attr}map")[name2]
         nnz = idx > 0
 
-        outshape = [subdata.shape[align_axis]] + list(arr.shape[:axis]) + list(arr.shape[axis + 1 :])
+        outshape = [subdata.shape[self._data.axis]] + list(arr.shape[:axis]) + list(arr.shape[axis + 1 :])
 
         out = np.full(outshape, fill_value=fill_value, dtype=np.promote_types(type(fill_value), arr.dtype), order="C")
         out[nnz, ...] = np.moveaxis(arr, axis, 0)[idx[nnz] - 1, ...]
         return np.moveaxis(out, 0, axis)
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_local_array_to_global(
         self,
         arr: NDArray[T],
         group_name: str,
         view_name: str,
-        align_to: Literal["samples", "features"],
+        align_to: Literal[0, 1],
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ):
@@ -242,23 +242,24 @@ class MuDataDataset(MofaFlexDataset):
             arr, view_name, group_name=group_name, align_to=align_to, axis=axis, fill_value=fill_value
         )
 
+    @MofaFlexDataset._axis_arg("align_to")
     def align_global_array_to_local(
-        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal["samples", "features"], axis: int = 0
+        self, arr: NDArray[T], group_name: str, view_name: str, align_to: Literal[0, 1], axis: int = 0
     ) -> NDArray[T]:
-        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
+        if self._data.axis == align_to:
             idx = self.map_local_indices_to_global(slice(None), group_name, view_name, align_to)
             return np.take(arr, idx, axis=axis)
         else:
             return arr
 
     def _map_local_indices_to_global(
-        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal["samples, features"], attr: str, axis: int
+        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal[0, 1], attr: str
     ) -> NDArray[int]:
-        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
+        if self._data.axis == align_to:
             subdata = self._data[(self._groups[name1], slice(None))[self._subset_reorder]]
             map = getattr(subdata, f"{attr}map")[name2]
             mask = map > 0
-            n = subdata.mod[name2].shape[axis]
+            n = subdata.mod[name2].shape[align_to]
             _idx = np.empty(n, dtype=map.dtype)
             _idx[map[mask] - 1] = np.arange(n, dtype=map.dtype) + np.cumsum(~mask)[mask]
 
@@ -267,9 +268,9 @@ class MuDataDataset(MofaFlexDataset):
             return idx
 
     def _map_global_indices_to_local(
-        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal["samples, features"], attr: str
+        self, idx: NDArray[int], name1: str, name2: str, align_to: Literal[0, 1], attr: str
     ) -> NDArray[int]:
-        if self._data.axis == 0 and align_to == "samples" or self._data.axis == 1 and align_to == "features":
+        if self._data.axis == align_to:
             subdata = self._data[(self._groups[name1], slice(None))[self._subset_reorder]]
             return getattr(subdata, f"{attr}map")[name2][idx].astype(int) - 1
         else:
@@ -637,21 +638,23 @@ class MuDataAxis0Dataset(MuDataDataset):
         view_name: str,
         subdata: MuData | None = None,
         group_name: str | None = None,
-        align_to: Literal["samples", "features"] = "samples",
+        align_to: Literal[0, 1] = 0,
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ) -> NDArray[T]:
         return self._align_local_array_to_global_impl(
-            arr, group_name, view_name, subdata, align_to, axis, fill_value, "obs", 0, "group_name"
+            arr, group_name, view_name, subdata, align_to, axis, fill_value, "obs", "group_name"
         )
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
-        return self._map_local_indices_to_global(idx, group_name, view_name, align_to, "obs", 0)
+        return self._map_local_indices_to_global(idx, group_name, view_name, align_to, "obs")
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         return self._map_global_indices_to_local(idx, group_name, view_name, align_to, "obs")
 
@@ -852,21 +855,23 @@ class MuDataAxis1Dataset(MuDataDataset):
         view_name: str,
         subdata: MuData | None = None,
         group_name: str | None = None,
-        align_to: Literal["samples", "features"] = "samples",
+        align_to: Literal[0, 1] = 0,
         axis: int = 0,
         fill_value: np.ScalarType = np.nan,
     ) -> NDArray[T]:
         return self._align_local_array_to_global_impl(
-            arr, view_name, group_name, subdata, align_to, axis, fill_value, "var", 1, "view_name"
+            arr, view_name, group_name, subdata, align_to, axis, fill_value, "var", "view_name"
         )
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_local_indices_to_global(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
-        return self._map_local_indices_to_global(idx, view_name, group_name, align_to, "var", 1)
+        return self._map_local_indices_to_global(idx, view_name, group_name, align_to, "var")
 
+    @MofaFlexDataset._axis_arg("align_to")
     def map_global_indices_to_local(
-        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal["samples, features"]
+        self, idx: NDArray[int], group_name: str, view_name: str, align_to: Literal[0, 1]
     ) -> NDArray[int]:
         return self._map_global_indices_to_local(idx, view_name, group_name, align_to, "var")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,3 +96,16 @@ def mousebrain_model():
 @pytest.fixture(scope="session")
 def mousebrain_data():
     return {"group_1": {"view_1": ad.read_h5ad(Path(__file__).parent / "data" / "mouse_brain.h5ad")}}
+
+
+@pytest.fixture(scope="session")
+def nonmissing_to_slice():
+    def func(nonmissing, expected_size):
+        if isinstance(nonmissing, slice):
+            return nonmissing
+        if nonmissing.size == expected_size and np.all(np.diff(nonmissing) == 1):
+            return slice(None)
+        else:
+            return nonmissing
+
+    return func

--- a/tests/test_anndatadataset.py
+++ b/tests/test_anndatadataset.py
@@ -58,7 +58,7 @@ def layer(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def dataset(adata, layer, subset_var):
     return MofaFlexDataset(adata, group_by="batch", layer=layer, subset_var=subset_var, cast_to=np.float32)
 
@@ -347,3 +347,31 @@ def test_get_missing_obs(adata, dataset):
         df = df.set_index("obs_name")
         assert np.all(df.loc[dataset.sample_names[group_name], "missing"][cmissing])
         assert np.all(~df.loc[dataset.sample_names[group_name], "missing"][~cmissing])
+
+
+def test_reindex_samples(adata, dataset, layer, rng):
+    samples1, samples2 = {}, {}
+    for group_name, group_samples in dataset.sample_names.items():
+        selection = rng.choice([True, False], size=len(group_samples), p=[0.5, 0.5])
+        samples1[group_name] = group_samples[selection]
+        samples2[group_name] = np.concatenate((group_samples[~selection], group_samples[selection][:2]))
+
+    for samples in (samples1, samples2):
+        dataset.reindex_samples(samples)
+        for group_name, group_samples in samples.items():
+            assert np.all(dataset.sample_names[group_name] == group_samples)
+        test_getitems(adata, dataset, layer, rng)
+
+
+def test_reindex_features(adata, dataset, layer, rng):
+    features1, features2 = {}, {}
+    for view_name, view_features in dataset.feature_names.items():
+        selection = rng.choice([True, False], size=len(view_features), p=[0.5, 0.5])
+        features1[view_name] = view_features[selection]
+        features2[view_name] = np.concatenate((view_features[~selection], view_features[selection][:2]))
+
+    for features in (features1, features2):
+        dataset.reindex_features(features)
+        for view_name, view_features in features.items():
+            assert np.all(dataset.feature_names[view_name] == view_features)
+        test_getitems(adata, dataset, layer, rng)

--- a/tests/test_anndatadictdataset.py
+++ b/tests/test_anndatadictdataset.py
@@ -72,7 +72,7 @@ def layer(request):
     return request.param
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def dataset(anndata_dict, layer, use_obs, use_var, subset_var):
     return MofaFlexDataset(
         anndata_dict, layer=layer, use_obs=use_obs, use_var=use_var, subset_var=subset_var, cast_to=np.float32
@@ -207,7 +207,7 @@ def test_index_mapping(anndata_dict, dataset, rng):
             assert np.all(global_idx[local_idx >= 0] == new_global_idx)
 
 
-def test_getitems(anndata_dict, dataset, layer, rng):
+def test_getitems(anndata_dict, dataset, layer, rng, nonmissing_to_slice):
     get_layer = lambda adata, layer: adata.layers[layer] if layer is not None else adata.X
     if layer is not None:
         if isinstance(layer, str):
@@ -255,8 +255,14 @@ def test_getitems(anndata_dict, dataset, layer, rng):
 
             cnonmissing_obs = np.nonzero(cobsidx)[0]
             cnonmissing_var = np.nonzero(cvaridx)[0]
-            assert np.all(items["nonmissing_samples"][group_name][view_name] == cnonmissing_obs)
-            assert np.all(items["nonmissing_features"][group_name][view_name] == cnonmissing_var)
+            assert np.all(
+                nonmissing_to_slice(items["nonmissing_samples"][group_name][view_name], cnonmissing_obs.size)
+                == nonmissing_to_slice(cnonmissing_obs, cnonmissing_obs.size)
+            )
+            assert np.all(
+                nonmissing_to_slice(items["nonmissing_features"][group_name][view_name], cnonmissing_var.size)
+                == nonmissing_to_slice(cnonmissing_var, cnonmissing_var.size)
+            )
 
 
 @pytest.mark.parametrize("usedask", [False, True])
@@ -404,3 +410,31 @@ def test_get_missing_obs(anndata_dict, dataset):
         df = df.set_index("obs_name")
         assert np.all(df.loc[dataset.sample_names[group_name], "missing"][cmissing])
         assert np.all(~df.loc[dataset.sample_names[group_name], "missing"][~cmissing])
+
+
+def test_reindex_samples(anndata_dict, dataset, layer, rng, nonmissing_to_slice):
+    samples1, samples2 = {}, {}
+    for group_name, group_samples in dataset.sample_names.items():
+        selection = rng.choice([True, False], size=len(group_samples), p=[0.5, 0.5])
+        samples1[group_name] = group_samples[selection]
+        samples2[group_name] = np.concatenate((group_samples[~selection], group_samples[selection][:2]))
+
+    for samples in (samples1, samples2):
+        dataset.reindex_samples(samples)
+        for group_name, group_samples in samples.items():
+            assert np.all(dataset.sample_names[group_name] == group_samples)
+        test_getitems(anndata_dict, dataset, layer, rng, nonmissing_to_slice)
+
+
+def test_reindex_features(anndata_dict, dataset, layer, rng, nonmissing_to_slice):
+    features1, features2 = {}, {}
+    for view_name, view_features in dataset.feature_names.items():
+        selection = rng.choice([True, False], size=len(view_features), p=[0.5, 0.5])
+        features1[view_name] = view_features[selection]
+        features2[view_name] = np.concatenate((view_features[~selection], view_features[selection][:2]))
+
+    for features in (features1, features2):
+        dataset.reindex_features(features)
+        for view_name, view_features in features.items():
+            assert np.all(dataset.feature_names[view_name] == view_features)
+        test_getitems(anndata_dict, dataset, layer, rng, nonmissing_to_slice)

--- a/tests/test_mudatadataset.py
+++ b/tests/test_mudatadataset.py
@@ -119,7 +119,7 @@ class MuDataDatasetTest:
 
         return mdata
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture(scope="function")
     def dataset(self, mdata, layer, subset_var):
         return MofaFlexDataset(mdata, group_by="batch", layer=layer, subset_var=subset_var, cast_to=np.float32)
 
@@ -230,7 +230,7 @@ class MuDataDatasetTest:
                 )
                 assert np.all(global_idx[local_idx >= 0] == new_global_idx)
 
-    def test_getitems(self, mdata, dataset, layer, rng):
+    def test_getitems(self, mdata, dataset, layer, rng, nonmissing_to_slice):
         if layer is not None:
             if isinstance(layer, str):
                 func = lambda modname: layer
@@ -273,15 +273,21 @@ class MuDataDatasetTest:
                 )
                 assert np.all(cdata.X == view)
 
-                cnonmissing_obs = np.nonzero(np.isin(sample_names, cdata.obs_names))[0]
-                if cnonmissing_obs.size == sample_names.size and np.all(np.diff(cnonmissing_obs) == 1):
-                    cnonmissing_obs = slice(None)
-                assert np.all(items["nonmissing_samples"][group_name][view_name] == cnonmissing_obs)
+                cnonmissing_obs = nonmissing_to_slice(
+                    np.nonzero(np.isin(sample_names, cdata.obs_names))[0], sample_names.size
+                )
+                assert np.all(
+                    nonmissing_to_slice(items["nonmissing_samples"][group_name][view_name], sample_names.size)
+                    == cnonmissing_obs
+                )
 
-                cnonmissing_var = np.nonzero(np.isin(feature_names, cdata.var_names))[0]
-                if cnonmissing_var.size == feature_names.size and np.all(np.diff(cnonmissing_var) == 1):
-                    cnonmissing_var = slice(None)
-                assert np.all(items["nonmissing_features"][group_name][view_name] == cnonmissing_var)
+                cnonmissing_var = nonmissing_to_slice(
+                    np.nonzero(np.isin(feature_names, cdata.var_names))[0], feature_names.size
+                )
+                assert np.all(
+                    nonmissing_to_slice(items["nonmissing_features"][group_name][view_name], feature_names.size)
+                    == cnonmissing_var
+                )
 
     @pytest.mark.parametrize("axis", [0, 1])
     def test_get_covariates_from_key(self, mdata, dataset, subset_var, axis):
@@ -372,6 +378,32 @@ class MuDataDatasetTest:
             df = df.set_index("obs_name")
             assert np.all(df.loc[dataset.sample_names[group_name], "missing"][cmissing])
             assert np.all(~df.loc[dataset.sample_names[group_name], "missing"][~cmissing])
+
+    def test_reindex_samples(self, mdata, dataset, layer, rng, nonmissing_to_slice):
+        samples1, samples2 = {}, {}
+        for group_name, group_samples in dataset.sample_names.items():
+            selection = rng.choice([True, False], size=len(group_samples), p=[0.5, 0.5])
+            samples1[group_name] = group_samples[selection]
+            samples2[group_name] = np.concatenate((group_samples[~selection], group_samples[selection][:2]))
+
+        for samples in (samples1, samples2):
+            dataset.reindex_samples(samples)
+            for group_name, group_samples in samples.items():
+                assert np.all(dataset.sample_names[group_name] == group_samples)
+            self.test_getitems(mdata, dataset, layer, rng, nonmissing_to_slice)
+
+    def test_reindex_features(self, mdata, dataset, layer, rng, nonmissing_to_slice):
+        features1, features2 = {}, {}
+        for view_name, view_features in dataset.feature_names.items():
+            selection = rng.choice([True, False], size=len(view_features), p=[0.5, 0.5])
+            features1[view_name] = view_features[selection]
+            features2[view_name] = np.concatenate((view_features[~selection], view_features[selection][:2]))
+
+        for features in (features1, features2):
+            dataset.reindex_features(features)
+            for view_name, view_features in features.items():
+                assert np.all(dataset.feature_names[view_name] == view_features)
+            self.test_getitems(mdata, dataset, layer, rng, nonmissing_to_slice)
 
 
 class TestMuDataAxis0Dataset(MuDataDatasetTest):

--- a/tests/test_mudatadataset.py
+++ b/tests/test_mudatadataset.py
@@ -9,81 +9,7 @@ from packaging.version import Version
 from scipy import sparse
 
 from mofaflex import settings
-from mofaflex._core.datasets import MofaFlexDataset, MuDataDataset
-
-
-@pytest.fixture(scope="module")
-def mdata(rng):
-    nobs = 500
-    nvar_per_mod = 20
-    ngroups = 4
-
-    obs_names = [f"cell_{i}" for i in range(nobs)]
-    adatas = {}
-    for view in range(3):
-        cobs_names = rng.choice(obs_names, size=int(0.8 * nobs), replace=False)
-        adata = ad.AnnData(
-            X=rng.poisson(0.5, size=(len(cobs_names), nvar_per_mod)),
-            layers={"layer1": rng.normal(0, 1, size=(len(cobs_names), nvar_per_mod)).astype(np.float32)},
-            obs=pd.DataFrame(index=cobs_names),
-            var=pd.DataFrame(index=[f"mod_{view}_feature_{i}" for i in range(nvar_per_mod)]),
-        )
-        if view < 2:
-            adata.obs["covar"] = rng.random(size=len(cobs_names))
-            adata.obsm["covar_df"] = pd.DataFrame(
-                rng.random(size=(len(cobs_names), 3)), columns=["a", "b", "c"], index=adata.obs_names
-            )
-            adata.obsm["covar_array"] = rng.random(size=(len(cobs_names), 3))
-            adata.obsm["covar_sparse"] = sparse.csr_array(rng.poisson(size=(len(cobs_names), 3)))
-            adata.var["covar"] = rng.random(size=adata.n_vars)
-            adata.varm["annot_df"] = pd.DataFrame(
-                rng.random(size=(nvar_per_mod, 10)),
-                columns=[f"annot_view_{view}_{i}" for i in range(10)],
-                index=adata.var_names,
-            )
-            adata.varm["annot_array"] = rng.random(size=(nvar_per_mod, 10))
-            adata.varm["annot_sparse"] = sparse.csr_array(rng.poisson(size=(nvar_per_mod, 4)))
-        adatas[f"view_{view}"] = adata
-
-    adatas["view_0"].X = sparse.csr_array(adatas["view_0"].X)
-    adatas["view_2"].X = sparse.csc_array(adatas["view_2"].X)
-    adatas["view_1"].var["highly_variable"] = rng.choice((True, False), size=nvar_per_mod, p=[0.4, 0.6])
-
-    mdata = md.MuData(adatas)
-
-    mdata.obs["batch"] = pd.Categorical(rng.choice(ngroups, size=mdata.n_obs).astype(str))
-
-    global_covar = rng.random(size=mdata.n_obs)
-    global_covar[~mdata.obs_names.isin(adatas["view_2"].obs_names)] = np.nan
-    mdata.obs["covar"] = global_covar
-
-    global_covar = rng.random(size=mdata.n_vars)
-    global_covar[~mdata.var_names.isin(adatas["view_2"].var_names)] = np.nan
-    mdata.var["covar"] = global_covar
-
-    global_covar = rng.random(size=(mdata.n_obs, 3))
-    global_covar[~mdata.obs_names.isin(adatas["view_2"].obs_names)] = np.nan
-    mdata.obsm["covar_df"] = pd.DataFrame(global_covar, columns=["a", "b", "c"], index=mdata.obs_names)
-    mdata.obsm["covar_array"] = rng.permuted(global_covar, axis=0)
-
-    global_covar_sparse = sparse.csr_array(rng.poisson(size=(mdata.n_obs, 3)).astype(np.float32))
-    global_covar_sparse[~mdata.obs_names.isin(adatas["view_2"].obs_names)] = np.nan
-    mdata.obsm["covar_sparse"] = global_covar_sparse
-
-    global_annot = rng.random(size=(mdata.n_vars, 10))
-    global_annot[~mdata.var_names.isin(adatas["view_2"].var_names)] = np.nan
-    mdata.varm["annot_df"] = pd.DataFrame(
-        global_annot, columns=[f"global_annot_{i}" for i in range(10)], index=mdata.var_names
-    )
-    mdata.varm["annot_array"] = rng.permuted(global_annot, axis=0)
-
-    global_annot_sparse = sparse.csr_array(rng.poisson(size=(mdata.n_var, 4)).astype(np.float32))
-    global_annot_sparse[~mdata.var_names.isin(adatas["view_2"].var_names)] = np.nan
-    mdata.varm["annot_sparse"] = global_annot_sparse
-
-    mdata.var["global_highly_variable"] = rng.choice((True, False), size=mdata.n_vars, p=[0.3, 0.7])
-
-    return mdata
+from mofaflex._core.datasets import MofaFlexDataset, MuDataAxis0Dataset, MuDataAxis1Dataset
 
 
 @pytest.fixture(scope="module", params=(None, "global_highly_variable", "highly_variable"))
@@ -91,346 +17,605 @@ def subset_var(request):
     return request.param
 
 
-@pytest.fixture(scope="module", params=(None, "layer1", {"view_0": "layer1", "view_1": None, "view_2": "layer1"}))
-def layer(request):
-    return request.param
-
-
-@pytest.fixture(scope="module")
-def dataset(mdata, layer, subset_var):
-    return MofaFlexDataset(mdata, group_by="batch", layer=layer, subset_var=subset_var, cast_to=np.float32)
-
-
-def get_varnames(mdata, modname, subset_var):
-    varnames = mdata.mod[modname].var_names
-    if subset_var in mdata.var:
-        varnames = varnames[mdata.var[subset_var][mdata.varmap[modname].reshape(-1) > 0]]
-    elif subset_var in mdata[modname].var:
-        varnames = varnames[mdata[modname].var[subset_var]]
-    return varnames
-
-
-def test_instance(dataset):
-    assert isinstance(dataset, MuDataDataset)
-
-
-def test_properties(mdata, dataset, subset_var):
-    assert sorted(dataset.group_names) == sorted(mdata.obs["batch"].unique())
-    assert sorted(dataset.view_names) == sorted(mdata.mod.keys())
-    for group_name, sample_names in dataset.sample_names.items():
-        cmdata = mdata[mdata.obs["batch"] == group_name, :]
-        assert np.all(np.sort(sample_names) == cmdata.obs_names.sort_values().to_numpy())
-        assert dataset.n_samples[group_name] == cmdata.n_obs
-
-    for view_name, view_names in dataset.feature_names.items():
-        cvarnames = get_varnames(mdata, view_name, subset_var)
-
-        assert np.all(view_names == cvarnames)
-        assert dataset.n_features[view_name] == cvarnames.size
-
-
-@pytest.mark.parametrize("axis", (0, 1, 2))
-def test_alignment(mdata, dataset, rng, axis):
-    ndim = 3
-
-    arr_shape = np.asarray([2] * ndim)
-
-    for group_name, group_samples in dataset.sample_names.items():
-        arr_shape[axis] = group_samples.size
-        global_arr = rng.random(size=arr_shape)
-        for view_name in dataset.view_names:
-            local_arr = dataset.align_global_array_to_local(
-                global_arr, group_name, view_name, align_to="samples", axis=axis
-            )
-            new_global_arr = dataset.align_local_array_to_global(
-                local_arr, group_name, view_name, align_to="samples", axis=axis, fill_value=np.nan
-            )
-            new_local_arr = dataset.align_global_array_to_local(
-                new_global_arr, group_name, view_name, align_to="samples", axis=axis
-            )
-
-            assert new_global_arr.shape == global_arr.shape
-            assert new_local_arr.shape == local_arr.shape
-            assert np.all(new_local_arr == local_arr)
-
-            mod = mdata[mdata.obs["batch"] == group_name, :][view_name]
-            local_obsnames = group_samples[np.isin(group_samples, mod.obs_names)]
-            idx = pd.Index(group_samples).get_indexer(local_obsnames)
-            assert np.all(local_arr == np.take(global_arr, idx, axis=axis))
-
-            idx = np.isin(group_samples, local_obsnames)
-            assert np.all(np.isnan(np.compress(~idx, new_global_arr, axis=axis)))
-            assert np.all(np.compress(idx, new_global_arr, axis=axis) == np.compress(idx, global_arr, axis=axis))
-
-    for view_name, view_features in dataset.feature_names.items():
-        arr_shape[axis] = view_features.size
-        global_arr = rng.random(size=arr_shape)
-        for group_name in dataset.group_names:
-            local_arr = dataset.align_global_array_to_local(
-                global_arr, group_name, view_name, align_to="features", axis=axis
-            )
-            new_global_arr = dataset.align_local_array_to_global(
-                local_arr, group_name, view_name, align_to="features", axis=axis, fill_value=np.nan
-            )
-            new_local_arr = dataset.align_global_array_to_local(
-                new_global_arr, group_name, view_name, align_to="features", axis=axis
-            )
-
-            assert new_global_arr.shape == global_arr.shape
-            assert new_local_arr.shape == local_arr.shape
-            assert np.all(new_local_arr == local_arr)
-
-            mod = mdata[mdata.obs["batch"] == group_name, :][view_name]
-            local_varnames = view_features[np.isin(view_features, mod.var_names)]
-            idx = pd.Index(view_features).get_indexer(local_varnames)
-            assert np.all(local_arr == np.take(global_arr, idx, axis=axis))
-
-            idx = np.isin(view_features, local_varnames)
-            assert np.all(np.isnan(np.compress(~idx, new_global_arr, axis=axis)))
-            assert np.all(np.compress(idx, new_global_arr, axis=axis) == np.compress(idx, global_arr, axis=axis))
-
-
-def test_index_mapping(mdata, dataset, rng):
-    for group_name, group_samples in dataset.sample_names.items():
-        global_idx = rng.choice(group_samples.size, size=int(0.3 * group_samples.size), replace=True)
-        for view_name in dataset.view_names:
-            local_idx = dataset.map_global_indices_to_local(global_idx, group_name, view_name, align_to="samples")
-
-            local_obsnames = mdata[mdata.obs["batch"] == group_name, :][view_name].obs_names.intersection(
-                group_samples, sort=False
-            )
-            assert np.all(group_samples[global_idx][local_idx >= 0] == local_obsnames[local_idx[local_idx >= 0]])
-            assert np.all(~np.isin(group_samples[global_idx][local_idx < 0], local_obsnames))
-
-            new_global_idx = dataset.map_local_indices_to_global(
-                local_idx[local_idx >= 0], group_name, view_name, align_to="samples"
-            )
-            assert np.all(global_idx[local_idx >= 0] == new_global_idx)
-
-    for view_name, view_features in dataset.feature_names.items():
-        global_idx = rng.choice(view_features.size, size=int(0.3 * view_features.size), replace=True)
-        for group_name in dataset.group_names:
-            local_idx = dataset.map_global_indices_to_local(global_idx, group_name, view_name, align_to="features")
-
-            local_varnames = mdata[mdata.obs["batch"] == group_name, :][view_name].var_names.intersection(
-                view_features, sort=False
-            )
-            assert np.all(view_features[global_idx][local_idx >= 0] == local_varnames[local_idx[local_idx >= 0]])
-            assert np.all(~np.isin(view_features[global_idx][local_idx < 0], local_varnames))
-
-            new_global_idx = dataset.map_local_indices_to_global(
-                local_idx[local_idx >= 0], group_name, view_name, align_to="features"
-            )
-            assert np.all(global_idx[local_idx >= 0] == new_global_idx)
-
-
-def test_getitems(mdata, dataset, layer, rng):
-    if layer is not None:
-        if isinstance(layer, str):
-            func = lambda modname: layer
+class MuDataDatasetTest:
+    @pytest.fixture(scope="class", params=(None, "layer1", {0: "layer1", 1: None, 2: "layer1"}))
+    def layer(self, request, mdata_axis):
+        if not isinstance(request.param, dict):
+            return request.param
         else:
-            func = lambda modname: layer[modname]
-        mods = {}
-        for modname in mdata.mod.keys():
-            adata = mdata.mod[modname]
-            clayer = func(modname)
-            mods[modname] = AnnData(
-                X=adata.X if clayer is None else adata.layers[clayer],
-                obs=adata.obs,
-                var=adata.var,
-                obsm=adata.obsm,
-                varm=adata.varm,
+            mod_key = "view" if mdata_axis == 0 else "group"
+            return {f"{mod_key}_{k}": layer for k, layer in request.param.items()}
+
+    @pytest.fixture(scope="class")
+    def mdata(self, rng, mdata_axis):
+        nobs = 500
+        nvar_per_mod = 20
+        ngroups = 4
+
+        obs_names = [f"cell_{i}" for i in range(nobs)]
+        var_names = [f"var_{i}" for i in range(nobs)]
+        if mdata_axis == 0:
+            adata_name_prefix = "view"
+            batch_prefix = "group"
+        else:
+            adata_name_prefix = "group"
+            batch_prefix = "view"
+        adatas = {}
+        for mod in range(3):
+            if mdata_axis == 0:
+                cobs_names = rng.choice(obs_names, size=int(0.8 * nobs), replace=False)
+                cvar_names = [f"mod_{mod}_feature_{i}" for i in range(nvar_per_mod)]
+            else:
+                cobs_names = [f"mod_{mod}_sample_{i}" for i in range(nvar_per_mod)]
+                cvar_names = rng.choice(var_names, size=int(0.8 * nobs), replace=False)
+
+            adata = ad.AnnData(
+                X=rng.poisson(0.5, size=(len(cobs_names), len(cvar_names))),
+                layers={"layer1": rng.normal(0, 1, size=(len(cobs_names), len(cvar_names))).astype(np.float32)},
+                obs=pd.DataFrame(index=cobs_names),
+                var=pd.DataFrame(index=cvar_names),
             )
-        new_mdata = MuData(mods, obs=mdata.obs, var=mdata.var, obsmap=mdata.obsmap, varmap=mdata.varmap)
-        new_mdata.obs = mdata.obs
-        new_mdata.var = mdata.var
-        mdata = new_mdata
+            if mod < 2:
+                adata.obs["covar"] = rng.random(size=adata.n_obs)
+                adata.obsm["covar_df"] = pd.DataFrame(
+                    rng.random(size=(adata.n_obs, 3)), columns=["a", "b", "c"], index=adata.obs_names
+                )
+                adata.obsm["covar_array"] = rng.random(size=(adata.n_obs, 3))
+                adata.obsm["covar_sparse"] = sparse.csr_array(rng.poisson(size=(adata.n_obs, 3)))
+                adata.var["covar"] = rng.random(size=adata.n_vars)
+                adata.varm["annot_df"] = pd.DataFrame(
+                    rng.random(size=(adata.n_vars, 10)),
+                    columns=[f"annot_view_{mod}_{i}" for i in range(10)],
+                    index=adata.var_names,
+                )
+                adata.varm["annot_array"] = rng.random(size=(adata.n_vars, 10))
+                adata.varm["annot_sparse"] = sparse.csr_array(rng.poisson(size=(adata.n_vars, 4)))
+            adatas[f"{adata_name_prefix}_{mod}"] = adata
 
-    idx = {
-        group_name: rng.choice(sample_names.size, size=sample_names.size // 3, replace=False)
-        for group_name, sample_names in dataset.sample_names.items()
-    }
-
-    items = dataset.__getitems__(idx)
-    for group_name, group in items["data"].items():
-        sample_names = dataset.sample_names[group_name][idx[group_name]]
-        assert np.all(items["sample_idx"][group_name] == idx[group_name])
-        for view_name, view in group.items():
-            assert type(view) is np.ndarray
-            assert view.dtype == np.float32
-
-            feature_names = dataset.feature_names[view_name]
-            cdata = mdata[sample_names, feature_names][view_name]
-            assert np.all(cdata.X == view)
-
-            cnonmissing_obs = np.nonzero(np.isin(sample_names, cdata.obs_names))[0]
-            assert np.all(items["nonmissing_samples"][group_name][view_name] == cnonmissing_obs)
-            assert items["nonmissing_features"][group_name][view_name] == slice(None)
-
-
-@pytest.mark.parametrize("usedask", [False, True])
-def test_apply_by_group_view(mdata, dataset, usedask):
-    def applyfun(adata, group_name, view_name, ref_sample_names, ref_feature_names):
-        assert np.all(
-            adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[view_name].obs_names, sort=False)
-        )
-        assert np.all(adata.var_names == ref_feature_names)
-
-    with settings.override(use_dask=usedask):
-        dataset.apply(
-            applyfun,
-            group_kwargs={"ref_sample_names": dataset.sample_names},
-            view_kwargs={"ref_feature_names": dataset.feature_names},
+        adatas[f"{adata_name_prefix}_0"].X = sparse.csr_array(adatas[f"{adata_name_prefix}_0"].X)
+        adatas[f"{adata_name_prefix}_2"].X = sparse.csc_array(adatas[f"{adata_name_prefix}_2"].X)
+        adatas[f"{adata_name_prefix}_1"].var["highly_variable"] = rng.choice(
+            (True, False), size=adata.n_vars, p=[0.4, 0.6]
         )
 
+        mdata = md.MuData(adatas, axis=mdata_axis)
 
-@pytest.mark.parametrize("usedask", [False, True])
-def test_apply_by_view(mdata, dataset, usedask):
-    def applyfun(adata, group_name, view_name):
-        assert np.all(adata.obs_names.sort_values() == mdata[view_name].obs_names.sort_values())
-        assert np.all(adata.var_names == dataset.feature_names[view_name])
-
-    with settings.override(use_dask=usedask):
-        dataset.apply(applyfun, by_group=False)
-
-
-@pytest.mark.xfail(
-    Version(ad.__version__) < Version("0.11.4"), reason="anndata bug: https://github.com/scverse/anndata/pull/1911"
-)
-@pytest.mark.parametrize("usedask", [False, True])
-def test_apply_by_group(mdata, dataset, subset_var, usedask):
-    varnames = np.concat(tuple(dataset.feature_names.values()))
-
-    def applyfun(adata, group_name, view_name):
-        assert np.all(adata.obs_names == dataset.sample_names[group_name])
-        assert np.all(adata.var_names == varnames)
-
-    with settings.override(use_dask=usedask):
-        dataset.apply(applyfun, by_view=False)
-
-
-@pytest.mark.parametrize("usedask", [False, True])
-def test_apply_to_view(mdata, dataset, usedask):
-    def applyfun(adata, group_name, ref_sample_names, ref_feature_names, _view_name):
-        assert np.all(
-            adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[_view_name].obs_names, sort=False)
+        mdata.obs["batch"] = pd.Categorical(
+            rng.choice([f"{batch_prefix}_{i}" for i in range(ngroups)], size=mdata.n_obs).astype(str)
         )
-        assert np.all(adata.var_names == ref_feature_names)
+        mdata.var["batch"] = pd.Categorical(
+            rng.choice([f"{batch_prefix}_{i}" for i in range(ngroups)], size=mdata.n_var).astype(str)
+        )
 
-    with settings.override(use_dask=usedask):
-        for view_name in dataset.view_names:
-            dataset.apply_to_view(
-                view_name,
+        global_covar = rng.random(size=mdata.n_obs)
+        global_covar[~mdata.obs_names.isin(adatas[f"{adata_name_prefix}_2"].obs_names)] = np.nan
+        mdata.obs["covar"] = global_covar
+
+        global_covar = rng.random(size=mdata.n_vars)
+        global_covar[~mdata.var_names.isin(adatas[f"{adata_name_prefix}_2"].var_names)] = np.nan
+        mdata.var["covar"] = global_covar
+
+        global_covar = rng.random(size=(mdata.n_obs, 3))
+        global_covar[~mdata.obs_names.isin(adatas[f"{adata_name_prefix}_2"].obs_names)] = np.nan
+        mdata.obsm["covar_df"] = pd.DataFrame(global_covar, columns=["a", "b", "c"], index=mdata.obs_names)
+        mdata.obsm["covar_array"] = rng.permuted(global_covar, axis=0)
+
+        global_covar_sparse = sparse.csr_array(rng.poisson(size=(mdata.n_obs, 3)).astype(np.float32))
+        global_covar_sparse[~mdata.obs_names.isin(adatas[f"{adata_name_prefix}_2"].obs_names)] = np.nan
+        mdata.obsm["covar_sparse"] = global_covar_sparse
+
+        global_annot = rng.random(size=(mdata.n_vars, 10))
+        global_annot[~mdata.var_names.isin(adatas[f"{adata_name_prefix}_2"].var_names)] = np.nan
+        mdata.varm["annot_df"] = pd.DataFrame(
+            global_annot, columns=[f"global_annot_{i}" for i in range(10)], index=mdata.var_names
+        )
+        mdata.varm["annot_array"] = rng.permuted(global_annot, axis=0)
+
+        global_annot_sparse = sparse.csr_array(rng.poisson(size=(mdata.n_var, 4)).astype(np.float32))
+        global_annot_sparse[~mdata.var_names.isin(adatas[f"{adata_name_prefix}_2"].var_names)] = np.nan
+        mdata.varm["annot_sparse"] = global_annot_sparse
+
+        mdata.var["global_highly_variable"] = rng.choice((True, False), size=mdata.n_vars, p=[0.3, 0.7])
+
+        return mdata
+
+    @pytest.fixture(scope="class")
+    def dataset(self, mdata, layer, subset_var):
+        return MofaFlexDataset(mdata, group_by="batch", layer=layer, subset_var=subset_var, cast_to=np.float32)
+
+    def test_properties(self, mdata, dataset, subset_var):
+        assert sorted(dataset.group_names) == sorted(self.get_group_names(mdata))
+        assert sorted(dataset.view_names) == sorted(self.get_view_names(mdata))
+        for group_name, sample_names in dataset.sample_names.items():
+            cmdata = self.get_mdata_subset(mdata, group_name=group_name)
+            assert np.all(np.sort(sample_names) == cmdata.obs_names.sort_values().to_numpy())
+            assert dataset.n_samples[group_name] == cmdata.n_obs
+
+        for view_name, view_names in dataset.feature_names.items():
+            cvarnames = self.get_varnames(mdata, subset_var, view_name=view_name)
+
+            assert np.all(view_names == cvarnames)
+            assert dataset.n_features[view_name] == cvarnames.size
+
+    @pytest.mark.parametrize("axis", (0, 1, 2))
+    def test_alignment(self, mdata, dataset, rng, axis):
+        ndim = 3
+
+        arr_shape = np.asarray([2] * ndim)
+
+        for group_name, group_samples in dataset.sample_names.items():
+            arr_shape[axis] = group_samples.size
+            global_arr = rng.random(size=arr_shape)
+            for view_name in dataset.view_names:
+                local_arr = dataset.align_global_array_to_local(
+                    global_arr, group_name, view_name, align_to="samples", axis=axis
+                )
+                new_global_arr = dataset.align_local_array_to_global(
+                    local_arr, group_name, view_name, align_to="samples", axis=axis, fill_value=np.nan
+                )
+                new_local_arr = dataset.align_global_array_to_local(
+                    new_global_arr, group_name, view_name, align_to="samples", axis=axis
+                )
+
+                assert new_global_arr.shape == global_arr.shape
+                assert new_local_arr.shape == local_arr.shape
+                assert np.all(new_local_arr == local_arr)
+
+                mod = self.get_mdata_subset(mdata, group_name=group_name, view_name=view_name)
+                local_obsnames = group_samples[np.isin(group_samples, mod.obs_names)]
+                idx = pd.Index(group_samples).get_indexer(local_obsnames)
+                assert np.all(local_arr == np.take(global_arr, idx, axis=axis))
+
+                idx = np.isin(group_samples, local_obsnames)
+                assert np.all(np.isnan(np.compress(~idx, new_global_arr, axis=axis)))
+                assert np.all(np.compress(idx, new_global_arr, axis=axis) == np.compress(idx, global_arr, axis=axis))
+
+        for view_name, view_features in dataset.feature_names.items():
+            arr_shape[axis] = view_features.size
+            global_arr = rng.random(size=arr_shape)
+            for group_name in dataset.group_names:
+                local_arr = dataset.align_global_array_to_local(
+                    global_arr, group_name, view_name, align_to="features", axis=axis
+                )
+                new_global_arr = dataset.align_local_array_to_global(
+                    local_arr, group_name, view_name, align_to="features", axis=axis, fill_value=np.nan
+                )
+                new_local_arr = dataset.align_global_array_to_local(
+                    new_global_arr, group_name, view_name, align_to="features", axis=axis
+                )
+
+                assert new_global_arr.shape == global_arr.shape
+                assert new_local_arr.shape == local_arr.shape
+                assert np.all(new_local_arr == local_arr)
+
+                mod = self.get_mdata_subset(mdata, group_name=group_name, view_name=view_name)
+                local_varnames = view_features[np.isin(view_features, mod.var_names)]
+                idx = pd.Index(view_features).get_indexer(local_varnames)
+                assert np.all(local_arr == np.take(global_arr, idx, axis=axis))
+
+                idx = np.isin(view_features, local_varnames)
+                assert np.all(np.isnan(np.compress(~idx, new_global_arr, axis=axis)))
+                assert np.all(np.compress(idx, new_global_arr, axis=axis) == np.compress(idx, global_arr, axis=axis))
+
+    def test_index_mapping(self, mdata, dataset, rng):
+        for group_name, group_samples in dataset.sample_names.items():
+            global_idx = rng.choice(group_samples.size, size=int(0.3 * group_samples.size), replace=True)
+            for view_name in dataset.view_names:
+                local_idx = dataset.map_global_indices_to_local(global_idx, group_name, view_name, align_to="samples")
+
+                local_obsnames = self.get_mdata_subset(
+                    mdata, group_name=group_name, view_name=view_name
+                ).obs_names.intersection(group_samples, sort=False)
+                assert np.all(group_samples[global_idx][local_idx >= 0] == local_obsnames[local_idx[local_idx >= 0]])
+                assert np.all(~np.isin(group_samples[global_idx][local_idx < 0], local_obsnames))
+
+                new_global_idx = dataset.map_local_indices_to_global(
+                    local_idx[local_idx >= 0], group_name, view_name, align_to="samples"
+                )
+                assert np.all(global_idx[local_idx >= 0] == new_global_idx)
+
+        for view_name, view_features in dataset.feature_names.items():
+            global_idx = rng.choice(view_features.size, size=int(0.3 * view_features.size), replace=True)
+            for group_name in dataset.group_names:
+                local_idx = dataset.map_global_indices_to_local(global_idx, group_name, view_name, align_to="features")
+
+                local_varnames = self.get_mdata_subset(
+                    mdata, group_name=group_name, view_name=view_name
+                ).var_names.intersection(view_features, sort=False)
+                assert np.all(view_features[global_idx][local_idx >= 0] == local_varnames[local_idx[local_idx >= 0]])
+                assert np.all(~np.isin(view_features[global_idx][local_idx < 0], local_varnames))
+
+                new_global_idx = dataset.map_local_indices_to_global(
+                    local_idx[local_idx >= 0], group_name, view_name, align_to="features"
+                )
+                assert np.all(global_idx[local_idx >= 0] == new_global_idx)
+
+    def test_getitems(self, mdata, dataset, layer, rng):
+        if layer is not None:
+            if isinstance(layer, str):
+                func = lambda modname: layer
+            else:
+                func = lambda modname: layer[modname]
+            mods = {}
+            for modname in mdata.mod.keys():
+                adata = mdata.mod[modname]
+                clayer = func(modname)
+                mods[modname] = AnnData(
+                    X=adata.X if clayer is None else adata.layers[clayer],
+                    obs=adata.obs,
+                    var=adata.var,
+                    obsm=adata.obsm,
+                    varm=adata.varm,
+                )
+            new_mdata = MuData(
+                mods, obs=mdata.obs, var=mdata.var, obsmap=mdata.obsmap, varmap=mdata.varmap, axis=mdata.axis
+            )
+            new_mdata.obs = mdata.obs
+            new_mdata.var = mdata.var
+            mdata = new_mdata
+
+        idx = {
+            group_name: rng.choice(sample_names.size, size=sample_names.size // 3, replace=False)
+            for group_name, sample_names in dataset.sample_names.items()
+        }
+
+        items = dataset.__getitems__(idx)
+        for group_name, group in items["data"].items():
+            sample_names = dataset.sample_names[group_name][idx[group_name]]
+            assert np.all(items["sample_idx"][group_name] == idx[group_name])
+            for view_name, view in group.items():
+                assert type(view) is np.ndarray
+                assert view.dtype == np.float32
+
+                feature_names = dataset.feature_names[view_name]
+                cdata = self.get_mdata_subset(
+                    mdata[sample_names, feature_names], group_name=group_name, view_name=view_name
+                )
+                assert np.all(cdata.X == view)
+
+                cnonmissing_obs = np.nonzero(np.isin(sample_names, cdata.obs_names))[0]
+                if cnonmissing_obs.size == sample_names.size and np.all(np.diff(cnonmissing_obs) == 1):
+                    cnonmissing_obs = slice(None)
+                assert np.all(items["nonmissing_samples"][group_name][view_name] == cnonmissing_obs)
+
+                cnonmissing_var = np.nonzero(np.isin(feature_names, cdata.var_names))[0]
+                if cnonmissing_var.size == feature_names.size and np.all(np.diff(cnonmissing_var) == 1):
+                    cnonmissing_var = slice(None)
+                assert np.all(items["nonmissing_features"][group_name][view_name] == cnonmissing_var)
+
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_get_covariates_from_key(self, mdata, dataset, subset_var, axis):
+        attr = "obs" if axis == 0 else "var"
+        namesattr = f"{attr}_names"
+        dsetnamesattr = "sample_names" if axis == 0 else "feature_names"
+        dict_reorder = slice(None) if axis == 0 else slice(None, None, -1)
+
+        covars = dataset.get_covariates(axis=axis, key="covar")
+        outer_iterator, inner_value, subset_reorder, get_subdata = self.get_covariates_from_key_params(dataset)
+
+        for outer_name in outer_iterator:
+            subdata = get_subdata(mdata, outer_name)
+            for modname in subdata.mod.keys():
+                dict_key = (outer_name, modname)[subset_reorder][dict_reorder]
+                assert covars[dict_key[0]][dict_key[1]].columns == ["covar"]
+
+                names = getattr(dataset, dsetnamesattr)[dict_key[0]]
+                if modname != inner_value:
+                    mod = subdata.mod[modname][:, self.get_varnames(subdata, subset_var, outer_name, modname)]
+                    globalidx = np.isin(names, getattr(mod, namesattr))
+                    localidx = getattr(mod, namesattr).get_indexer(names)
+                    localidx = localidx[localidx >= 0]
+                    assert np.all(
+                        covars[dict_key[0]][dict_key[1]].iloc[globalidx, 0].squeeze()
+                        == getattr(mod, attr)["covar"].to_numpy()[localidx]
+                    )
+                    assert np.all(np.isnan(covars[dict_key[0]][dict_key[1]].iloc[~globalidx, 0]))
+                else:
+                    covar = getattr(subdata, attr).loc[names, "covar"].to_numpy()
+                    nanidx = np.isnan(covar)
+                    assert np.all(covar[~nanidx] == covars[dict_key[0]][dict_key[1]].iloc[~nanidx, 0].squeeze())
+                    assert np.all(np.isnan(covars[dict_key[0]][dict_key[1]].iloc[nanidx, 0]))
+
+    @pytest.mark.parametrize("type", ("df", "array", "sparse"))
+    @pytest.mark.parametrize("axis, mkey", [(0, "covar"), (1, "annot")])
+    def test_get_covariates_from_keym(self, mdata, dataset, subset_var, axis, mkey, type):
+        mkey = f"{mkey}_{type}"
+        attr = "obs" if axis == 0 else "var"
+        attrm = f"{attr}m"
+        namesattr = f"{attr}_names"
+        dsetnamesattr = "sample_names" if axis == 0 else "feature_names"
+        dict_reorder = slice(None) if axis == 0 else slice(None, None, -1)
+
+        covars = dataset.get_covariates(axis=axis, mkey=mkey)
+        outer_iterator, inner_value, subset_reorder, _ = self.get_covariates_from_key_params(dataset)
+
+        for outer_name in outer_iterator:
+            for modname in mdata.mod.keys():
+                group_name, view_name = (outer_name, modname)[subset_reorder]
+                dict_key = (group_name, view_name)[dict_reorder]
+                names = getattr(dataset, dsetnamesattr)[dict_key[0]]
+                subdata = mdata[dataset.sample_names[group_name], dataset.feature_names[view_name]]
+                ccovars = covars[dict_key[0]][dict_key[1]]
+                if modname != inner_value:
+                    view = subdata.mod[modname]
+
+                    globalidx = np.isin(names, getattr(view, namesattr))
+                    localidx = getattr(view, namesattr).get_indexer(names)
+                    localidx = localidx[localidx >= 0]
+
+                    gt = getattr(view, attrm)[mkey]
+                    if type == "df":
+                        gt = gt.iloc[localidx, :].to_numpy()
+                    else:
+                        gt = gt[localidx, :]
+                    if type == "sparse":
+                        gt = gt.toarray()
+                    assert np.all(ccovars.iloc[globalidx, :] == gt)
+                    assert np.all(np.isnan(ccovars.iloc[~globalidx, :]))
+                else:
+                    covar = getattr(subdata, attrm)[mkey]
+                    if type == "df":
+                        assert np.all(ccovars.columns == covar.columns)
+                        covar = covar.to_numpy()
+                    elif type == "sparse":
+                        covar = covar.toarray()
+                    ccovars = ccovars.to_numpy()
+                    nanidx = np.isnan(covar)
+                    assert np.all(covar[~nanidx] == ccovars[~nanidx])
+                    assert np.all(np.isnan(ccovars[nanidx]))
+
+    def test_get_missing_obs(self, mdata, dataset):
+        missing = dataset.get_missing_obs()
+        for (group_name, view_name), df in missing.groupby(["group", "view"]):
+            view = self.get_mdata_subset(mdata, group_name, view_name)
+            cmissing = ~np.isin(dataset.sample_names[group_name], view.obs_names)
+            df = df.set_index("obs_name")
+            assert np.all(df.loc[dataset.sample_names[group_name], "missing"][cmissing])
+            assert np.all(~df.loc[dataset.sample_names[group_name], "missing"][~cmissing])
+
+
+class TestMuDataAxis0Dataset(MuDataDatasetTest):
+    @pytest.fixture(scope="class")
+    def mdata_axis(self, request):
+        return 0
+
+    @staticmethod
+    def get_varnames(mdata, subset_var, group_name=None, view_name=None):
+        varnames = mdata.mod[view_name].var_names
+        if subset_var in mdata.var:
+            varnames = varnames[mdata.var[subset_var][mdata.varmap[view_name].reshape(-1) > 0]]
+        elif subset_var in mdata[view_name].var:
+            varnames = varnames[mdata[view_name].var[subset_var]]
+        return varnames
+
+    @staticmethod
+    def get_group_names(mdata):
+        return mdata.obs["batch"].unique()
+
+    @staticmethod
+    def get_view_names(mdata):
+        return mdata.mod.keys()
+
+    @staticmethod
+    def get_mdata_subset(mdata, group_name=None, view_name=None):
+        if group_name is not None:
+            mdata = mdata[mdata.obs["batch"] == group_name, :]
+        if view_name is not None:
+            mdata = mdata[view_name]
+        return mdata
+
+    @staticmethod
+    def get_covariates_from_key_params(dataset):
+        return (
+            dataset.group_names,
+            "view_2",
+            slice(None),
+            lambda mdata, group_name: mdata[mdata.obs["batch"] == group_name, :],
+        )
+
+    def test_instance(self, dataset, mdata_axis):
+        assert isinstance(dataset, MuDataAxis0Dataset)
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_group_view(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, view_name, ref_sample_names, ref_feature_names):
+            assert np.all(
+                adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[view_name].obs_names, sort=False)
+            )
+            assert np.all(adata.var_names == ref_feature_names)
+
+        with settings.override(use_dask=usedask):
+            dataset.apply(
                 applyfun,
                 group_kwargs={"ref_sample_names": dataset.sample_names},
-                ref_feature_names=dataset.feature_names[view_name],
-                _view_name=view_name,
-            )
-
-
-@pytest.mark.parametrize("usedask", [False, True])
-def test_apply_to_group(mdata, dataset, usedask):
-    def applyfun(adata, view_name, ref_sample_names, ref_feature_names):
-        assert np.all(
-            adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[view_name].obs_names, sort=False)
-        )
-        assert np.all(adata.var_names == ref_feature_names)
-
-    with settings.override(use_dask=usedask):
-        for group_name in dataset.group_names:
-            dataset.apply_to_group(
-                group_name,
-                applyfun,
                 view_kwargs={"ref_feature_names": dataset.feature_names},
-                ref_sample_names=dataset.sample_names[group_name],
             )
 
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_view(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, view_name):
+            assert np.all(adata.obs_names.sort_values() == mdata[view_name].obs_names.sort_values())
+            assert np.all(adata.var_names == dataset.feature_names[view_name])
 
-@pytest.mark.parametrize("axis", [0, 1])
-def test_get_covariates_from_key(mdata, dataset, subset_var, axis):
-    attr = "obs" if axis == 0 else "var"
-    namesattr = f"{attr}_names"
-    dsetnamesattr = "sample_names" if axis == 0 else "feature_names"
-    dict_reorder = slice(None) if axis == 0 else slice(None, None, -1)
+        with settings.override(use_dask=usedask):
+            dataset.apply(applyfun, by_group=False)
 
-    covars = dataset.get_covariates(axis=axis, key="covar")
+    @pytest.mark.xfail(
+        Version(ad.__version__) < Version("0.11.4"), reason="anndata bug: https://github.com/scverse/anndata/pull/1911"
+    )
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_group(self, mdata, dataset, usedask):
+        varnames = np.concat(tuple(dataset.feature_names.values()))
 
-    for group_name in dataset.group_names:
-        subdata = mdata[mdata.obs["batch"] == group_name]
-        for modname in subdata.mod.keys():
-            dict_key = (group_name, modname)[dict_reorder]
-            assert covars[dict_key[0]][dict_key[1]].columns == ["covar"]
+        def applyfun(adata, group_name, view_name):
+            assert np.all(adata.obs_names == dataset.sample_names[group_name])
+            assert np.all(adata.var_names == varnames)
 
-            names = getattr(dataset, dsetnamesattr)[dict_key[0]]
-            if modname != "view_2":
-                view = subdata.mod[modname][:, get_varnames(subdata, modname, subset_var)]
-                globalidx = np.isin(names, getattr(view, namesattr))
-                localidx = getattr(view, namesattr).get_indexer(names)
-                localidx = localidx[localidx >= 0]
-                assert np.all(
-                    covars[dict_key[0]][dict_key[1]].iloc[globalidx, 0].squeeze()
-                    == getattr(view, attr)["covar"].to_numpy()[localidx]
+        with settings.override(use_dask=usedask):
+            dataset.apply(applyfun, by_view=False)
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_to_view(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, ref_sample_names, ref_feature_names, _view_name):
+            assert np.all(
+                adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[_view_name].obs_names, sort=False)
+            )
+            assert np.all(adata.var_names == ref_feature_names)
+
+        with settings.override(use_dask=usedask):
+            for view_name in dataset.view_names:
+                dataset.apply_to_view(
+                    view_name,
+                    applyfun,
+                    group_kwargs={"ref_sample_names": dataset.sample_names},
+                    ref_feature_names=dataset.feature_names[view_name],
+                    _view_name=view_name,
                 )
-                assert np.all(np.isnan(covars[dict_key[0]][dict_key[1]].iloc[~globalidx, 0]))
-            else:
-                covar = getattr(subdata, attr).loc[names, "covar"].to_numpy()
-                nanidx = np.isnan(covar)
-                assert np.all(covar[~nanidx] == covars[dict_key[0]][dict_key[1]].iloc[~nanidx, 0].squeeze())
-                assert np.all(np.isnan(covars[dict_key[0]][dict_key[1]].iloc[nanidx, 0]))
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_to_group(self, mdata, dataset, usedask):
+        def applyfun(adata, view_name, ref_sample_names, ref_feature_names):
+            assert np.all(
+                adata.obs_names == pd.Index(ref_sample_names).intersection(mdata[view_name].obs_names, sort=False)
+            )
+            assert np.all(adata.var_names == ref_feature_names)
+
+        with settings.override(use_dask=usedask):
+            for group_name in dataset.group_names:
+                dataset.apply_to_group(
+                    group_name,
+                    applyfun,
+                    view_kwargs={"ref_feature_names": dataset.feature_names},
+                    ref_sample_names=dataset.sample_names[group_name],
+                )
 
 
-@pytest.mark.parametrize("type", ("df", "array", "sparse"))
-@pytest.mark.parametrize("axis, mkey", [(0, "covar"), (1, "annot")])
-def test_get_covariates_from_keym(mdata, dataset, subset_var, axis, mkey, type):
-    mkey = f"{mkey}_{type}"
-    attr = "obs" if axis == 0 else "var"
-    attrm = f"{attr}m"
-    namesattr = f"{attr}_names"
-    dsetnamesattr = "sample_names" if axis == 0 else "feature_names"
-    dict_reorder = slice(None) if axis == 0 else slice(None, None, -1)
+class TestMuDataAxis1Dataset(MuDataDatasetTest):
+    @pytest.fixture(scope="class")
+    def mdata_axis(self, request):
+        return 1
 
-    covars = dataset.get_covariates(axis=axis, mkey=mkey)
+    @staticmethod
+    def get_varnames(mdata, subset_var, view_name=None, group_name=None):
+        mask = mdata.var["batch"] == view_name
+        if subset_var in mdata.var:
+            mask &= mdata.var[subset_var]
+        else:
+            for modname, mod in mdata.mod.items():
+                if subset_var in mod.var:
+                    map = mdata.varmap[modname].ravel()
+                    mapmask = map > 0
+                    cmask = np.zeros_like(mask)
+                    cmask[mapmask] = mod.var[subset_var][map[mapmask] - 1]
+                    mask &= cmask
+        if group_name is not None:
+            mapmask = mdata.varmap[group_name].ravel()
+            return mdata.var_names[mapmask > 0 & mask]
+        else:
+            return mdata.var_names[mask]
 
-    for group_name in dataset.group_names:
-        for modname in mdata.mod.keys():
-            dict_key = (group_name, modname)[dict_reorder]
-            names = getattr(dataset, dsetnamesattr)[dict_key[0]]
-            subdata = mdata[dataset.sample_names[group_name], dataset.feature_names[modname]]
-            ccovars = covars[dict_key[0]][dict_key[1]]
-            if modname != "view_2":
-                view = subdata.mod[modname]
+    @staticmethod
+    def get_group_names(mdata):
+        return mdata.mod.keys()
 
-                globalidx = np.isin(names, getattr(view, namesattr))
-                localidx = getattr(view, namesattr).get_indexer(names)
-                localidx = localidx[localidx >= 0]
+    @staticmethod
+    def get_view_names(mdata):
+        return mdata.var["batch"].unique()
 
-                gt = getattr(view, attrm)[mkey]
-                if type == "df":
-                    gt = gt.iloc[localidx, :].to_numpy()
-                else:
-                    gt = gt[localidx, :]
-                if type == "sparse":
-                    gt = gt.toarray()
-                assert np.all(ccovars.iloc[globalidx, :] == gt)
-                assert np.all(np.isnan(ccovars.iloc[~globalidx, :]))
-            else:
-                covar = getattr(subdata, attrm)[mkey]
-                if type == "df":
-                    assert np.all(ccovars.columns == covar.columns)
-                    covar = covar.to_numpy()
-                elif type == "sparse":
-                    covar = covar.toarray()
-                ccovars = ccovars.to_numpy()
-                nanidx = np.isnan(covar)
-                assert np.all(covar[~nanidx] == ccovars[~nanidx])
-                assert np.all(np.isnan(ccovars[nanidx]))
+    @staticmethod
+    def get_mdata_subset(mdata, group_name=None, view_name=None):
+        if view_name is not None:
+            mdata = mdata[:, mdata.var["batch"] == view_name]
+        if group_name is not None:
+            mdata = mdata[group_name]
+        return mdata
 
+    @staticmethod
+    def get_covariates_from_key_params(dataset):
+        return (
+            dataset.view_names,
+            "group_2",
+            slice(None, None, -1),
+            lambda mdata, view_name: mdata[:, mdata.var["batch"] == view_name],
+        )
 
-def test_get_missing_obs(mdata, dataset):
-    missing = dataset.get_missing_obs()
-    for (group_name, view_name), df in missing.groupby(["group", "view"]):
-        view = mdata[mdata.obs["batch"] == group_name, :][view_name]
-        cmissing = ~np.isin(dataset.sample_names[group_name], view.obs_names)
-        df = df.set_index("obs_name")
-        assert np.all(df.loc[dataset.sample_names[group_name], "missing"][cmissing])
-        assert np.all(~df.loc[dataset.sample_names[group_name], "missing"][~cmissing])
+    def test_instance(self, dataset, mdata_axis):
+        assert isinstance(dataset, MuDataAxis1Dataset)
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_group_view(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, view_name, ref_sample_names, ref_feature_names):
+            assert np.all(adata.obs_names == ref_sample_names)
+            assert np.all(
+                adata.var_names == pd.Index(ref_feature_names).intersection(mdata[group_name].var_names, sort=False)
+            )
+
+        with settings.override(use_dask=usedask):
+            dataset.apply(
+                applyfun,
+                group_kwargs={"ref_sample_names": dataset.sample_names},
+                view_kwargs={"ref_feature_names": dataset.feature_names},
+            )
+
+    @pytest.mark.xfail(
+        Version(ad.__version__) < Version("0.11.4"), reason="anndata bug: https://github.com/scverse/anndata/pull/1911"
+    )
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_view(self, mdata, dataset, usedask):
+        obsnames = np.concat(tuple(dataset.sample_names.values()))
+
+        def applyfun(adata, group_name, view_name):
+            assert np.all(adata.obs_names == obsnames)
+            assert np.all(adata.var_names == dataset.feature_names[view_name])
+
+        with settings.override(use_dask=usedask):
+            dataset.apply(applyfun, by_group=False)
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_by_group(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, view_name):
+            assert np.all(adata.obs_names == dataset.sample_names[group_name])
+
+            for vname in np.unique(view_name):
+                assert np.all(
+                    adata.var_names[view_name == vname].sort_values()
+                    == mdata[group_name].var_names.intersection(dataset.feature_names[vname]).sort_values()
+                )
+
+        with settings.override(use_dask=usedask):
+            dataset.apply(applyfun, by_view=False)
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_to_view(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, ref_sample_names, ref_feature_names):
+            assert np.all(adata.obs_names == ref_sample_names)
+            assert np.all(
+                adata.var_names == pd.Index(ref_feature_names).intersection(mdata[group_name].var_names, sort=False)
+            )
+
+        with settings.override(use_dask=usedask):
+            for view_name in dataset.view_names:
+                dataset.apply_to_view(
+                    view_name,
+                    applyfun,
+                    group_kwargs={"ref_sample_names": dataset.sample_names},
+                    ref_feature_names=dataset.feature_names[view_name],
+                )
+
+    @pytest.mark.parametrize("usedask", [False, True])
+    def test_apply_to_group(self, mdata, dataset, usedask):
+        def applyfun(adata, group_name, ref_sample_names, ref_feature_names, _group_name):
+            assert np.all(adata.obs_names == ref_sample_names)
+            assert np.all(
+                adata.var_names == pd.Index(ref_feature_names).intersection(mdata[_group_name].var_names, sort=False)
+            )
+
+        with settings.override(use_dask=usedask):
+            for group_name in dataset.group_names:
+                dataset.apply_to_group(
+                    group_name,
+                    applyfun,
+                    view_kwargs={"ref_feature_names": dataset.feature_names},
+                    ref_sample_names=dataset.sample_names[group_name],
+                    _group_name=group_name,
+                )


### PR DESCRIPTION
- Implement a dataloader for MuData objects with `axis=1`. Most of the implementation is generalized from the existing MuData loader. For MuData objects with `axis=1`, the modalities will be treated as groups and the `group_by` argument will be used to split the data into views based on a `.var` column
- Simplify axis argument handling in the dataloaders: Introduce a custom decorator that maps the value of the axis argument to either 0 or 1, even if a string like "samples" or "features" was given. This unifies axis handling across all methods and simplifies the methods themselves.
- more unit tests