### PR TITLE
move all documentation-specific processing to Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,12 +6,9 @@
 
 # -- Path setup --------------------------------------------------------------
 import sys
-import os
 from datetime import datetime
 from importlib.metadata import metadata
 from pathlib import Path
-
-os.environ["MOFAFLEX_DOCS"] = "1"
 
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE / "extensions"))

--- a/docs/extensions/dynamicapi.py
+++ b/docs/extensions/dynamicapi.py
@@ -1,0 +1,130 @@
+import inspect
+from functools import update_wrapper
+
+from pydocstring import Docstring, Parameter, Section, SectionKind, emit_google, parse_google
+
+import mofaflex as mfl
+from mofaflex._core.priors import APIType
+from mofaflex._core.terms import Term, MofaFlex
+from mofaflex._core.api import types
+
+
+def get_doc(obj) -> Docstring:
+    doc = inspect.getdoc(obj)
+    if doc is None:
+        doc = Docstring()
+    else:
+        doc = parse_google(doc).to_model()
+    return doc
+
+
+def setup(app):
+    # prior API wrapper admonitions
+    for apicls, apiclsname in ((getattr(mfl.priors, cls), cls) for cls in dir(mfl.priors) if cls != "Prior"):
+        implcls = getattr(mfl._core.priors, apiclsname)
+        doc = get_doc(apicls)
+        msgs = ""
+        if (f := implcls.factors_allowed()) != implcls.weights_allowed():
+            msgs += f".. important::\n   This prior can only be used for {'factors' if f else 'weights'}.\n\n"
+        if len(implcls.api()) > 0:
+            msgs += ".. important::\n   All methods and properties of this class are only accessible through the :class:`~.terms.MofaFlex` class.\n\n"
+
+        if doc.extended_summary is None:
+            doc.extended_summary = msgs
+        else:
+            doc.extended_summary = f"{msgs}{doc.extended_summary}"
+        apicls.__doc__ = emit_google(doc)
+
+    # MofaFlex term dynamic api
+    apinames = mfl._core.terms.mofaflex._apinames
+    getters = MofaFlex.get_factors, MofaFlex.get_weights
+    for axis, priors in enumerate(
+        (mfl._core.priors.Prior.known_priors("factors"), mfl._core.priors.Prior.known_priors("weights"))
+    ):
+        getter_doc = get_doc(getters[axis])
+        getter_signature_params = inspect.signature(getters[axis]).parameters
+        getter_sections = getter_doc.sections
+        getter_params_section_idx, getter_params = next(
+            (i, section.parameters)
+            for i, section in enumerate(getter_doc.sections)
+            if section.kind == SectionKind.PARAMETERS
+        )
+        seen_getter_params = {param.names[0] for param in getter_params}
+
+        for prior, priorcls in priors.items():
+            for api in priorcls.api():
+                name = apinames[(axis, prior, api.name)]
+                wrappedapi = getattr(MofaFlex, name)
+                doc = get_doc(wrappedapi)
+                desc = doc.extended_summary or ""
+                if api.type == APIType.property and not api.has_factors:
+                    desc = f".. important::\n   This property is only available when using the :class:`~.priors.{prior}` prior.\n\n{desc}"
+
+                    Term._api(MofaFlex, name)
+                    setattr(getattr(mfl.priors, prior), name, getattr(priorcls, api.name))
+                else:
+                    desc = f".. important::\n   This method is only available when using the :class:`~.priors.{prior}` prior.\n\n{desc}"
+                    if api.has_factors:
+                        sections = doc.sections
+                        param = Parameter(
+                            names=["ordered"],
+                            description="Whether to return the factors ordered by explained variance (highest to lowest).",
+                        )
+                        for s, section in enumerate(sections):
+                            if section.kind == SectionKind.PARAMETERS:
+                                params = section.parameters
+                                params.append(param)
+                                sections[s] = Section(section.kind, parameters=params)
+                                break
+                        else:
+                            sections.append(Section(SectionKind.PARAMETERS, parameters=[param]))
+                        doc.sections = sections
+
+                    wrapper2 = lambda self, *args, **kwargs: None
+                    wrapper2.__signature__ = wrappedapi.__signature__
+                    update_wrapper(wrapper2, wrappedapi)
+                    wrapper2.__doc__ = emit_google(doc)
+                    setattr(getattr(mfl._core.api.priors, prior), name, wrapper2)
+                    Term._api(MofaFlex, name)
+
+                if len(desc) > 0:
+                    doc.extended_summary = desc
+                wrappedapi.__doc__ = emit_google(doc)
+
+            postprocess_doc = get_doc(priorcls.postprocess_results)
+            if params := next(
+                (section.parameters for section in postprocess_doc.sections if section.kind == SectionKind.PARAMETERS),
+                None,
+            ):
+                for param in params:
+                    if param.names[0] not in seen_getter_params and param.names[0] in getter_signature_params:
+                        desc = param.description
+                        if desc is None:
+                            desc = ""
+                        desc += f"\n\n.. important::\n   This argument is only available when using the :class:`~.priors.{prior}` prior."
+                        param.description = desc
+                        getter_params.append(param)
+        getter_sections[getter_params_section_idx] = Section(SectionKind.PARAMETERS, parameters=getter_params)
+        getter_doc.sections = getter_sections
+        getters[axis].__doc__ = emit_google(getter_doc)
+
+    # terms
+    for apicls, apiclsname in ((getattr(mfl.terms, cls), cls) for cls in dir(mfl.terms)):
+        implcls = getattr(mfl._core.terms, apiclsname)
+        wrapper = type(apiclsname, (), {"__module__": apicls.__module__, "__doc__": implcls.__doc__})
+        wrapper.__init__ = implcls.__init__
+        for api in implcls.api():
+            setattr(wrapper, api, getattr(implcls, api))
+        setattr(mfl.terms, apiclsname, wrapper)
+        setattr(types.terms, apiclsname, wrapper)
+    types.terms.Term = None
+
+    # likelihoods
+    for apicls, apiclsname in (
+        (getattr(mfl.likelihoods, cls), cls) for cls in dir(mfl.likelihoods) if cls != "Likelihood"
+    ):
+        implcls = getattr(mfl._core.likelihoods, apiclsname)
+        for api in implcls.api():
+            setattr(apicls, api, getattr(implcls, api))
+        setattr(types.likelihoods, apiclsname, apicls)
+    types.likelihoods.Likelihood = None

--- a/docs/extensions/dynamicapi.py
+++ b/docs/extensions/dynamicapi.py
@@ -5,7 +5,7 @@ from pydocstring import Docstring, Parameter, Section, SectionKind, emit_google,
 
 import mofaflex as mfl
 from mofaflex._core.priors import APIType
-from mofaflex._core.terms import Term, MofaFlex
+from mofaflex._core.terms import MofaFlex
 from mofaflex._core.api import types
 
 
@@ -60,7 +60,6 @@ def setup(app):
                 if api.type == APIType.property and not api.has_factors:
                     desc = f".. important::\n   This property is only available when using the :class:`~.priors.{prior}` prior.\n\n{desc}"
 
-                    Term._api(MofaFlex, name)
                     setattr(getattr(mfl.priors, prior), name, getattr(priorcls, api.name))
                 else:
                     desc = f".. important::\n   This method is only available when using the :class:`~.priors.{prior}` prior.\n\n{desc}"
@@ -85,7 +84,6 @@ def setup(app):
                     update_wrapper(wrapper2, wrappedapi)
                     wrapper2.__doc__ = emit_google(doc)
                     setattr(getattr(mfl._core.api.priors, prior), name, wrapper2)
-                    Term._api(MofaFlex, name)
 
                 if len(desc) > 0:
                     doc.extended_summary = desc
@@ -114,7 +112,7 @@ def setup(app):
         wrapper = type(apiclsname, (), {"__module__": apicls.__module__, "__doc__": implcls.__doc__})
         wrapper.__init__ = implcls.__init__
         for api in implcls.api():
-            setattr(wrapper, api, getattr(implcls, api))
+            setattr(wrapper, api.name, getattr(implcls, api.name))
         setattr(mfl.terms, apiclsname, wrapper)
         setattr(types.terms, apiclsname, wrapper)
     types.terms.Term = None
@@ -125,6 +123,6 @@ def setup(app):
     ):
         implcls = getattr(mfl._core.likelihoods, apiclsname)
         for api in implcls.api():
-            setattr(apicls, api, getattr(implcls, api))
+            setattr(apicls, api.name, getattr(implcls, api.name))
         setattr(types.likelihoods, apiclsname, apicls)
     types.likelihoods.Likelihood = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ doc = [
   "ipykernel",
   "ipython",
   "myst-nb>=1.1",
+  "pydocstring-rs>=0.1.13",
   "sphinx>=8.1",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",

--- a/src/mofaflex/_core/api/_generate.py
+++ b/src/mofaflex/_core/api/_generate.py
@@ -1,10 +1,7 @@
 import sys
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from inspect import Parameter, signature
-
-from ..utils import building_docs
-from .utils import DynamicAPIMixin
 
 
 class APIWrapper(ABC):
@@ -28,12 +25,7 @@ class APIWrapper(ABC):
         return hash((self.__class__, self._args, tuple(sorted(self._kwargs.items()))))
 
 
-def init_api(
-    module: str,
-    basecls: type,
-    subclss: Mapping[str, type],
-    doc_callback: Callable[[str | None, type], str | None] | None = None,
-):
+def init_api(module: str, basecls: type, subclss: Mapping[str, type]):
     mod = sys.modules[module]
     coreinit = basecls.__dict__.get("__init__", None)
     if coreinit is not None:
@@ -75,12 +67,7 @@ def init_api(
         apicls = type(
             subname, (basewrapper,), {"_cls": subcls, "__init__": init, "__call__": call, "__module__": module}
         )
-        apicls.__doc__ = subcls.__doc__ if doc_callback is None else doc_callback(subcls.__doc__, subcls)
-
-        if building_docs() and issubclass(basecls, DynamicAPIMixin):
-            for api in subcls.api():
-                setattr(apicls, api, getattr(subcls, api))
-
+        apicls.__doc__ = subcls.__doc__
         setattr(mod, subname, apicls)
         all_.append(subname)
 

--- a/src/mofaflex/_core/api/priors.py
+++ b/src/mofaflex/_core/api/priors.py
@@ -1,19 +1,4 @@
 from ..priors import Prior
-from ..utils import docstring_get_indentation as _indent
 from . import _generate
 
-
-def _doc_callback(doc: str | None, priorcls: type[Prior]):
-    if (f := priorcls.factors_allowed()) != priorcls.weights_allowed():
-        msg = (".. important::\n", f"   This prior can only be used for {'factors' if f else 'weights'}.\n")
-        if doc is None:
-            return "".join(msg)
-        else:
-            indent = _indent(doc)
-            lines = doc.splitlines(keepends=True)
-            return "".join((lines[0], "\n", *(" " * indent + cmsg for cmsg in msg), *lines[1:]))
-    else:
-        return doc
-
-
-_generate.init_api(__name__, Prior, Prior.known_priors(), _doc_callback)
+_generate.init_api(__name__, Prior, Prior.known_priors())

--- a/src/mofaflex/_core/api/terms.py
+++ b/src/mofaflex/_core/api/terms.py
@@ -2,7 +2,6 @@ from inspect import Parameter, Signature, signature
 from typing import TYPE_CHECKING
 
 from ..terms import Term
-from ..utils import building_docs
 
 __all__ = []
 
@@ -20,21 +19,15 @@ def _init_api():
         return wrapper
 
     for termname, term in Term.known_terms().items():
-        if not building_docs():
-            wrapper = make_wrapper(term)
-            sig = signature(term.__init__)
-            params = [signature(wrapper).parameters["name"]] + [
-                Parameter(param.name, Parameter.KEYWORD_ONLY, default=param.default, annotation=param.annotation)
-                for param in sig.parameters.values()
-            ]
-            wrapper.__signature__ = Signature(params)
-            wrapper.__annotations__ = term.__init__.__annotations__ | {"name": str, "return": "MOFAFLEX"}
-            wrapper.__doc__ = term.__doc__
-        else:
-            wrapper = type(termname, (), {"__module__": __name__, "__doc__": term.__doc__})
-            wrapper.__init__ = term.__init__
-            for api in term.api():
-                setattr(wrapper, api, getattr(term, api))
+        wrapper = make_wrapper(term)
+        sig = signature(term.__init__)
+        params = [signature(wrapper).parameters["name"]] + [
+            Parameter(param.name, Parameter.KEYWORD_ONLY, default=param.default, annotation=param.annotation)
+            for param in sig.parameters.values()
+        ]
+        wrapper.__signature__ = Signature(params)
+        wrapper.__annotations__ = term.__init__.__annotations__ | {"name": str, "return": "MOFAFLEX"}
+        wrapper.__doc__ = term.__doc__
 
         globals()[termname] = wrapper
         __all__.append(termname)

--- a/src/mofaflex/_core/api/types.py
+++ b/src/mofaflex/_core/api/types.py
@@ -3,8 +3,6 @@ def _generate():
 
     from ..likelihoods import Likelihood
     from ..terms import Term
-    from ..utils import building_docs
-    from . import likelihoods, terms  # noqa: F401
     from .utils import DynamicAPIWrapper
 
     for docsapi, basecls, subclss in (
@@ -12,15 +10,9 @@ def _generate():
         ("likelihoods", Likelihood, Likelihood.known_likelihoods()),
     ):
         mod = ModuleType(docsapi)
-        if building_docs():
-            apimod = locals()[docsapi]
-            for wrapper in dir(apimod):
-                setattr(mod, wrapper, getattr(apimod, wrapper))
-            setattr(mod, basecls.__name__, None)
-        else:
-            for clsname, subcls in subclss.items():
-                setattr(mod, clsname, DynamicAPIWrapper[subcls])
-            setattr(mod, basecls.__name__, DynamicAPIWrapper[basecls])
+        for clsname, subcls in subclss.items():
+            setattr(mod, clsname, DynamicAPIWrapper[subcls])
+        setattr(mod, basecls.__name__, DynamicAPIWrapper[basecls])
         globals()[docsapi] = mod
 
 

--- a/src/mofaflex/_core/api/utils.py
+++ b/src/mofaflex/_core/api/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from itertools import chain
 from types import MethodType
 from typing import TYPE_CHECKING, Generic, TypeVar
@@ -19,6 +20,20 @@ class _class_and_instancemethod:
         return obj.__get__(instance, owner)
 
 
+@dataclass(kw_only=True, frozen=True)
+class DynamicAPI:
+    name: str
+    hidden: bool = False
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other: str | DynamicAPI):
+        if isinstance(other, __class__):
+            other = other.name
+        return self.name == other
+
+
 class DynamicAPIMixin:
     """Mixin class for classes that define a subset of their API as user-facing.
 
@@ -27,28 +42,30 @@ class DynamicAPIMixin:
     be defined both at the class level as well as for individual instances.
     """
 
-    _apilist = []
+    _apiset = set()
 
     @_class_and_instancemethod
     def api(self) -> Iterable[str]:
         """The user-facing API of class / object."""
-        return self._apilist
+        return self._apiset
 
     @_class_and_instancemethod
-    def api_methods(self) -> Iterable[str]:
+    def api_methods(self) -> Iterable[DynamicAPI]:
         """The user-facing methods of this class / object."""
         obj = self.__class__ if isinstance(self, __class__) else self
-        return (api for api in self._apilist if not isinstance(getattr(obj, api, None), property))
+        return (api for api in self._apiset if not isinstance(getattr(obj, api.name, None), property))
 
     @_class_and_instancemethod
-    def api_properties(self) -> Iterable[str]:
+    def api_properties(self) -> Iterable[DynamicAPI]:
         """The user-facing properties of this class / object."""
         obj = self.__class__ if isinstance(self, __class__) else self
-        return (api for api in self._apilist if isinstance(getattr(obj, api, None), property))
+        return (api for api in self._apiset if isinstance(getattr(obj, api.name, None), property))
 
     def _api(
-        obj: Callable | property | DynamicAPIMixin | type[DynamicAPIMixin],
+        obj: Callable | property | DynamicAPIMixin | type[DynamicAPIMixin] | None,
         attr: MethodType | property | str | None = None,
+        *,
+        hidden: bool = False,
     ):
         """Mark a method or property as user-facing.
 
@@ -85,9 +102,11 @@ class DynamicAPIMixin:
         """
 
         def _add_api(owner, api: str):
-            if "_apilist" not in owner.__dict__:
-                owner._apilist = owner._apilist.copy()
-            owner._apilist.append(api)
+            if "_apiset" not in owner.__dict__:
+                owner._apiset = owner._apiset.copy()
+            api = DynamicAPI(name=api, hidden=hidden)
+            owner._apiset.discard(api)
+            owner._apiset.add(api)
 
         class __api:
             def __new__(cls, func: Callable | MethodType | property):
@@ -98,6 +117,7 @@ class DynamicAPIMixin:
                     return super().__new__(cls)
 
             def __init__(self, func: Callable | property):
+                self._hidden = hidden
                 self._func = func
                 if isinstance(func, property):
                     self.setter = self._setter
@@ -115,7 +135,9 @@ class DynamicAPIMixin:
                 self._func = self._func.deleter(func)
                 return self
 
-        if isinstance(obj, Callable | property) and not isinstance(obj, __class__) and not isinstance(obj, type):
+        if obj is None:
+            return __api
+        elif isinstance(obj, Callable | property) and not isinstance(obj, __class__) and not isinstance(obj, type):
             return __api(obj)
         elif isinstance(attr, MethodType):
             return __api(attr)
@@ -142,11 +164,8 @@ class DynamicAPIWrapper(Generic[T]):
         self._forward = forward
 
     def __dir__(self, forward: bool | None = None):
-        return (
-            chain(self._model.__dir__(), self._wrapped.api())
-            if forward or forward is None and self._forward
-            else self._wrapped.api()
-        )
+        apis = (api.name for api in self._wrapped.api() if not api.hidden)
+        return chain(self._model.__dir__(), apis) if forward or forward is None and self._forward else apis
 
     def __getattr__(self, name, forward: bool | None = None):
         err = AttributeError(

--- a/src/mofaflex/_core/priors/__init__.py
+++ b/src/mofaflex/_core/priors/__init__.py
@@ -4,7 +4,7 @@ from .base import API, APIType, Prior
 from .constant import Constant
 from .gaussian_process import GaussianProcess
 from .gsfa import GSFA
-from .horseshoe import InformedHorseshoe
+from .horseshoe import Horseshoe, InformedHorseshoe
 from .simple_location_scale import *  # noqa F403
 from .spike_slab import SpikeSlab
 

--- a/src/mofaflex/_core/priors/spike_slab.py
+++ b/src/mofaflex/_core/priors/spike_slab.py
@@ -257,8 +257,7 @@ class SpikeSlab(Prior):
         sparse_type: Literal["raw", "mix", "thresh"] = "mix",
         **kwargs,
     ) -> dict[str, NDArray[np.number]] | NDArray[np.number] | None:
-        """Args.
-
+        """Args:
         sparse_type: How to handle sparsity when using the spike and slab prior.
 
             - raw: Do nothing, return inferred values for all entries.
@@ -267,7 +266,7 @@ class SpikeSlab(Prior):
               inferred non-sparse value. The mixture is weighted by the inferred
               sparsity probability. This is what MOFA does.
             - thresh: Set all values with a sparsity probablity > 0.5 to 0.
-        """
+        """  # noqa: D205
         if name is not None:
             if name in self.names:
                 return self._postprocess_name(results, moment, name, sparse_type)

--- a/src/mofaflex/_core/terms/mofaflex.py
+++ b/src/mofaflex/_core/terms/mofaflex.py
@@ -900,6 +900,7 @@ def _init_api():
                     attr = property(make_dummy_function(name, prior, True))
                     attr.__doc__ = getattr(priorcls, api.name).__doc__
                     setattr(MofaFlex, name, attr)
+                    Term._api(MofaFlex, name, hidden=True)
                     continue
 
                 func = getattr(priorcls, api.name)
@@ -927,6 +928,7 @@ def _init_api():
                     wrapperfunc.__name__ = name
 
                 setattr(MofaFlex, name, wrapperfunc)
+                Term._api(MofaFlex, name, hidden=True)
 
             postprocess_method = priorcls.postprocess_results
             params = [

--- a/src/mofaflex/_core/terms/mofaflex.py
+++ b/src/mofaflex/_core/terms/mofaflex.py
@@ -26,14 +26,7 @@ from ..api import priors as apipriors
 from ..datasets import CovariatesDataset, MofaFlexDataset, StackDataset, df_to_array, merge_covariates
 from ..likelihoods.pyro import Likelihood
 from ..priors import API, APIType, FactorPriorType, Prior, WeightPriorType
-from ..utils import (
-    MeanStd,
-    PyroModuleDict,
-    PyroParameterDict,
-    building_docs,
-    change_pyro_plate_dim,
-    default_torch_device,
-)
+from ..utils import MeanStd, PyroModuleDict, PyroParameterDict, change_pyro_plate_dim, default_torch_device
 from .base import Term
 
 _logger = logging.getLogger(__name__)
@@ -859,7 +852,6 @@ class MofaFlex(Term):
 
 # init API for docs
 def _init_api():
-    from ..utils import docstring_get_indentation
 
     def raise_(exc):
         raise exc
@@ -888,10 +880,7 @@ def _init_api():
         {"self", "results", "moment", "name", "kwargs"},
     )
     getter_annots = tuple(getter.__annotations__ for getter in getters)
-    getter_docs = [getter.__doc__ for getter in getters]
-    getter_indents = [" " * docstring_get_indentation(doc) for doc in getter_docs]
 
-    seen_priors = set()
     for axis, axisname, priors in (
         (0, "factor", Prior.known_priors("factors")),
         (1, "weight", Prior.known_priors("weights")),
@@ -900,18 +889,6 @@ def _init_api():
         duplicates = {k for k, v in namescount.items() if v > 1}
 
         for prior, priorcls in priors.items():
-            if building_docs() and prior not in seen_priors and len(priorcls.api()):
-                apiprior = getattr(apipriors, prior)
-                doc = apiprior.__doc__
-                if doc is None:
-                    doc = ""
-                indent = " " * docstring_get_indentation(doc)
-                apiprior.__doc__ = (
-                    doc + f"\n\n{indent}.. important::\n"
-                    f"{indent}   All methods and properties of this class are only accessible through the :class:`~.terms.MofaFlex` class."
-                )
-                seen_priors.add(prior)
-
             for api in priorcls.api():
                 name = api.name if api.name not in duplicates else f"{api.name}_{prior}"
                 name = name.replace("a̲x̲i̲s̲", axisname)
@@ -921,18 +898,8 @@ def _init_api():
 
                 if api.type == APIType.property and not api.has_factors:
                     attr = property(make_dummy_function(name, prior, True))
-                    propdoc = getattr(priorcls, api.name).__doc__
-                    if propdoc is None:
-                        propdoc = ""
-                    attr.__doc__ = (
-                        propdoc + "\n\n.. important::\n"
-                        f"   This property is only available when using the :class:`~.priors.{prior}` prior."
-                    )
+                    attr.__doc__ = getattr(priorcls, api.name).__doc__
                     setattr(MofaFlex, name, attr)
-
-                    if building_docs():
-                        Term._api(MofaFlex, name)
-                        setattr(getattr(apipriors, prior), name, getattr(priorcls, api.name))
                     continue
 
                 func = getattr(priorcls, api.name)
@@ -943,20 +910,10 @@ def _init_api():
                 params = list(sig.parameters.values())
                 annots = func.__annotations__.copy()
                 wrapperfunc = make_dummy_function(name, prior, False)
-                if api.has_factors or building_docs():
-                    indent = " " * docstring_get_indentation(doc)
+                wrapperfunc.__doc__ = doc
                 if not api.has_factors:
-                    wrapperfunc.__doc__ = doc
                     wrapperfunc.__signature__ = sig
                 else:
-                    if doc is not None:
-                        doc += "\n\n"
-                    else:
-                        doc = ""
-                    wrapperfunc.__doc__ = (
-                        doc + f"{indent}Args:\n"
-                        f"{indent}    ordered: Whether to return the factors ordered by explained variance (highest to lowest).\n\n"
-                    )
                     params.append(
                         inspect.Parameter(
                             "ordered", inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False, annotation=bool
@@ -969,19 +926,6 @@ def _init_api():
                     wrapperfunc.__qualname__ = f"{MofaFlex.__qualname__}.{name}"
                     wrapperfunc.__name__ = name
 
-                if building_docs():
-                    wrapperfunc2 = make_dummy_function(name, prior, False)  # can't copy function objects'
-                    wrapperfunc2.__signature__ = wrapperfunc.__signature__
-                    update_wrapper(wrapperfunc2, wrapperfunc)
-                    setattr(getattr(apipriors, prior), name, wrapperfunc2)
-                    Term._api(MofaFlex, name)
-
-                if wrapperfunc.__doc__ is None:
-                    wrapperfunc.__doc__ = ""
-                wrapperfunc.__doc__ += (
-                    f"\n{indent}.. important::\n"
-                    f"{indent}   This method is only available when using the :class:`~.priors.{prior}` prior.\n"
-                )
                 setattr(MofaFlex, name, wrapperfunc)
 
             postprocess_method = priorcls.postprocess_results
@@ -998,18 +942,6 @@ def _init_api():
                     else:
                         getter_annots[axis][param.name] |= param.annotation
                     getter_ignored_params[axis].add(param.name)
-                if doc := postprocess_method.__doc__:
-                    docindent = docstring_get_indentation(doc)
-                    lines = doc.expandtabs(4).splitlines()
-                    lines[0] = getter_indents[axis] + "Args:"
-                    for i, line in enumerate(lines[1:]):
-                        lines[i + 1] = getter_indents[axis] + "    " + line[docindent:]
-                    doc = "\n".join(lines)
-                    getter_docs[axis] += (
-                        "\n"
-                        + doc
-                        + f"\n{getter_indents[axis]}        .. important::\n{getter_indents[axis]}           This argument is only available when using the :class:`~.priors.{prior}` prior."
-                    )
 
     # can't move this inside the loop due to Python's late binding closures
     getter_wrappers = (
@@ -1019,7 +951,7 @@ def _init_api():
     for axis, (method, wrapper) in enumerate(zip(getters, getter_wrappers, strict=True)):
         wrapper.__signature__ = getter_sigs[axis].replace(parameters=getter_params[axis])
         wrapper.__annotations__ = getter_annots[axis]
-        wrapper.__doc__ = getter_docs[axis]
+        wrapper.__doc__ = getters[axis].__doc__
         wrapper.__qualname__ = method.__qualname__
         wrapper.__name__ = method.__name__
         setattr(MofaFlex, method.__name__, wrapper)

--- a/src/mofaflex/_core/utils.py
+++ b/src/mofaflex/_core/utils.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import builtins
 import logging
-import os
 from abc import ABC
 from collections import namedtuple
 from collections.abc import Iterable, Mapping, Sequence
@@ -248,27 +246,6 @@ def change_pyro_plate_dim(plate: pyro.plate | Iterable[pyro.plate], new_dim: int
             for plate_ in plate:
                 stack.enter_context(change_pyro_plate_dim(plate_, new_dim))
             yield plate
-
-
-def building_docs() -> bool:
-    return "MOFAFLEX_DOCS" in os.environ
-
-
-def docstring_get_line_indentation(line: str):
-    for i, s in enumerate(line):
-        if not s.isspace():
-            return i
-    return np.inf
-
-
-def docstring_get_indentation(docstring: str):
-    if not docstring:
-        return 0
-    lines = docstring.expandtabs(4).splitlines()
-    min_indent = np.inf
-    for line in lines[1:]:
-        min_indent = builtins.min(min_indent, docstring_get_line_indentation(line))
-    return min_indent if np.isfinite(min_indent) else 0
 
 
 def pickle_torch_state(state: dict) -> NDArray[np.uint8]:

--- a/src/mofaflex/tl/_downstream.py
+++ b/src/mofaflex/tl/_downstream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 import numpy as np
@@ -72,7 +74,7 @@ def test_annotation_significance(
         return {}
 
 
-def factor_correlation(model: MOFAFLEX) -> dict[str, pd.DataFrame]:
+def factor_correlation(model: types.terms.MofaFlex | MOFAFLEX) -> dict[str, pd.DataFrame]:
     """Calculate the correlation between factors.
 
     Args:

--- a/tests/test_mofaflex_integration.py
+++ b/tests/test_mofaflex_integration.py
@@ -7,6 +7,7 @@ from functools import reduce
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 from scipy.sparse import SparseEfficiencyWarning, csc_array, csc_matrix, csr_array, csr_matrix, issparse
 
@@ -223,6 +224,8 @@ def test_integration(
         assert model.n_informed_factors > 0
         assert model.terms["_"].n_informed_factors > 0
         assert model.n_informed_factors == model.terms["_"].n_informed_factors
+        assert "get_annotations" in dir(model)
+        assert all(isinstance(annot, pd.DataFrame) for annot in model.get_annotations().values())
     elif argname == "guiding_vars_obs_keys":
         assert model.n_guided_factors == model.terms["_"].n_guided_factors == 3
     else:
@@ -233,6 +236,9 @@ def test_integration(
             == model.terms["_"].n_total_factors
             == 5
         )
+        assert "get_annotations" not in dir(model)
+        with pytest.raises(AttributeError, match="is only available when using the 'InformedHorseshoe' prior"):
+            model.get_annotations()
 
     if fitargs.get("save_path") is not False:
         loaded_model = MOFAFLEX.load(path=next(iter(tmp_path.glob("*.h5"))))


### PR DESCRIPTION
Currently, everything is done at import time, including docstring parsing and processing. Some code also has different branches depending on whether we are currently building documentation or not to enable nice-looking internal cross-references.

This PR moves all of that to a custom Sphinx extension. This has several advantages:
- We can use a proper docstring parsing library instead of our custom, admittedly brittle, code, without making it a runtime dependency.
- faster import, since we don't need to do all that string processing at import time.
- cleaner code: The core only handles what it needs to do for the dynamic API, all documentation-specific stuff is separate, instead of being sprinkled all over core.