### PR TITLE
unify dynamic API implementations

### DIFF
--- a/docs/extensions/dynamicapi.py
+++ b/docs/extensions/dynamicapi.py
@@ -4,7 +4,7 @@ from functools import update_wrapper
 from pydocstring import Docstring, Parameter, Section, SectionKind, emit_google, parse_google
 
 import mofaflex as mfl
-from mofaflex._core.priors import APIType
+from mofaflex._core.api.utils import APIType
 from mofaflex._core.terms import MofaFlex
 from mofaflex._core.api import types
 

--- a/src/mofaflex/_core/api/utils.py
+++ b/src/mofaflex/_core/api/utils.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from enum import Enum, auto
+from functools import partial
 from itertools import chain
 from types import MethodType
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
 if TYPE_CHECKING:
     from .mofaflex import MOFAFLEX
@@ -20,10 +22,23 @@ class _class_and_instancemethod:
         return obj.__get__(instance, owner)
 
 
+class APIType(Enum):
+    method = auto()
+    property = auto()
+
+
 @dataclass(kw_only=True, frozen=True)
 class DynamicAPI:
+    """Description of a user-facing API attribute."""
+
     name: str
+    """The name of the attribute."""
+
+    type: APIType
+    """The type of the attribute (method or property)."""
+
     hidden: bool = False
+    """Whether the attribute is hidden. Hidden attributes are not listed by `dir()`, but can still be accessed."""
 
     def __hash__(self):
         return hash(self.name)
@@ -34,6 +49,37 @@ class DynamicAPI:
         return self.name == other
 
 
+class DynamicAPIDecorator:
+    @staticmethod
+    def add_api(owner, api: str, type, **kwargs):
+        if "__dynamicapi_apiset__" not in owner.__dict__:
+            owner.__dynamicapi_apiset__ = owner.__dynamicapi_apiset__.copy()
+        api = owner.__dynamicapi_apicls__(name=api, type=type, **kwargs)
+        owner.__dynamicapi_apiset__.discard(api)
+        owner.__dynamicapi_apiset__.add(api)
+
+    def __init__(self, func: Callable | property, **kwargs):
+        self._func = func
+        self._kwargs = kwargs
+        if isinstance(func, property):
+            self.setter = self._setter
+            self.deleter = self._deleter
+
+    def __set_name__(self, owner, name: str):
+        self.add_api(
+            owner, name, APIType.property if isinstance(self._func, property) else APIType.method, **self._kwargs
+        )
+        setattr(owner, name, self._func)
+
+    def _setter(self, func):
+        self._func = self._func.setter(func)
+        return self
+
+    def _deleter(self, func):
+        self._func = self._func.deleter(func)
+        return self
+
+
 class DynamicAPIMixin:
     """Mixin class for classes that define a subset of their API as user-facing.
 
@@ -42,31 +88,40 @@ class DynamicAPIMixin:
     be defined both at the class level as well as for individual instances.
     """
 
-    _apiset = set()
+    __dynamicapi_apiset__ = set()
+    __dynamicapi_apicls__ = DynamicAPI
+    __dynamicapi_decorator_cls__ = DynamicAPIDecorator
+
+    def __init_subclass__(
+        subcls,
+        *,
+        dynapi_cls: type[DynamicAPI] | None = None,
+        dynapi_decorator_cls: type[DynamicAPIDecorator] | None = None,
+        **kwargs,
+    ):
+        super().__init_subclass__(**kwargs)
+        if dynapi_cls is not None:
+            subcls.__dynamicapi_apicls__ = dynapi_cls
+        if dynapi_decorator_cls is not None:
+            subcls.__dynamicapi_decorator_cls__ = dynapi_decorator_cls
 
     @_class_and_instancemethod
     def api(self) -> Iterable[str]:
         """The user-facing API of class / object."""
-        return self._apiset
+        return self.__dynamicapi_apiset__
 
     @_class_and_instancemethod
     def api_methods(self) -> Iterable[DynamicAPI]:
         """The user-facing methods of this class / object."""
-        obj = self.__class__ if isinstance(self, __class__) else self
-        return (api for api in self._apiset if not isinstance(getattr(obj, api.name, None), property))
+        return (api for api in self.__dynamicapi_apiset__ if api.type == APIType.method)
 
     @_class_and_instancemethod
     def api_properties(self) -> Iterable[DynamicAPI]:
         """The user-facing properties of this class / object."""
-        obj = self.__class__ if isinstance(self, __class__) else self
-        return (api for api in self._apiset if isinstance(getattr(obj, api.name, None), property))
+        return (api for api in self.__dynamicapi_apiset__ if api.type == APIType.property)
 
-    def _api(
-        obj: Callable | property | DynamicAPIMixin | type[DynamicAPIMixin] | None,
-        attr: MethodType | property | str | None = None,
-        *,
-        hidden: bool = False,
-    ):
+    @_class_and_instancemethod
+    def _api(self: type[Self], obj: Callable | MethodType | property | str | None = None, **kwargs):
         """Mark a method or property as user-facing.
 
         Subclasses can use this to expose properties or methods to the end user.
@@ -100,51 +155,26 @@ class DynamicAPIMixin:
             >>> def foobar(self, *args):
             ...     self._api(self.baz)
         """
-
-        def _add_api(owner, api: str):
-            if "_apiset" not in owner.__dict__:
-                owner._apiset = owner._apiset.copy()
-            api = DynamicAPI(name=api, hidden=hidden)
-            owner._apiset.discard(api)
-            owner._apiset.add(api)
-
-        class __api:
-            def __new__(cls, func: Callable | MethodType | property):
-                if isinstance(func, MethodType):
-                    _add_api(func.__self__, func.__name__)
-                    return None
-                else:
-                    return super().__new__(cls)
-
-            def __init__(self, func: Callable | property):
-                self._hidden = hidden
-                self._func = func
-                if isinstance(func, property):
-                    self.setter = self._setter
-                    self.deleter = self._deleter
-
-            def __set_name__(self, owner, name: str):
-                _add_api(owner, name)
-                setattr(owner, name, self._func)
-
-            def _setter(self, func):
-                self._func = self._func.setter(func)
-                return self
-
-            def _deleter(self, func):
-                self._func = self._func.deleter(func)
-                return self
-
-        if obj is None:
-            return __api
-        elif isinstance(obj, Callable | property) and not isinstance(obj, __class__) and not isinstance(obj, type):
-            return __api(obj)
-        elif isinstance(attr, MethodType):
-            return __api(attr)
-        elif attr is None:
-            raise ValueError("Need attr if invoked on a DynamicAPIMixin instance.")
-        _add_api(obj, attr)
-        return obj
+        if isinstance(self, type) and issubclass(self, __class__) and obj is None:
+            return partial(self._api, **kwargs)
+        elif isinstance(self, type) and issubclass(self, __class__) and isinstance(obj, Callable | property):
+            return self.__dynamicapi_decorator_cls__(obj, **kwargs)
+        elif isinstance(self, __class__) and isinstance(obj, MethodType):
+            self.__dynamicapi_decorator_cls__.add_api(obj.__self__, obj.__name__, APIType.method, **kwargs)
+            return None
+        elif isinstance(obj, str):
+            cls = self.__class__ if isinstance(self, __class__) else self
+            type_ = APIType.method
+            try:
+                if isinstance(getattr(cls, obj), property):
+                    type_ = APIType.property
+            except AttributeError:
+                if not isinstance(getattr(self, obj), MethodType):
+                    type_ = APIType.property
+            self.__dynamicapi_decorator_cls__.add_api(self, obj, type_, **kwargs)
+            return None
+        else:
+            raise TypeError("Unknown argument type for 'obj'")
 
 
 T = TypeVar("T", bound=DynamicAPIMixin)

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -26,7 +26,7 @@ class R2(NamedTuple):
 @checked_baseclass(
     required_init_args=("view_name", "data", "nonnegative"), required_attributes="_priority", registry="dict"
 )
-class Likelihood(SaveStateMixin, DynamicAPIMixin, ABC):
+class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
     """Base class for MOFA-FLEX likelihoods.
 
     Subclasses must contain the `priority` attribute, which is used during likelihood inference to return the

--- a/src/mofaflex/_core/priors/__init__.py
+++ b/src/mofaflex/_core/priors/__init__.py
@@ -1,6 +1,6 @@
 from typing import Literal, TypeAlias
 
-from .base import API, APIType, Prior
+from .base import Prior, PriorDynamicAPI
 from .constant import Constant
 from .gaussian_process import GaussianProcess
 from .gsfa import GSFA

--- a/src/mofaflex/_core/priors/base.py
+++ b/src/mofaflex/_core/priors/base.py
@@ -89,10 +89,12 @@ class Prior(
     _apilist = []
     _state_attrs = "_names"
 
-    def __init_subclass__(cls, **kwargs):
+    def __init_subclass__(cls, *, factors: bool = True, weights: bool = True, **kwargs):
         if not isabstract(cls) and cls.__name__[0] != "_":
-            if not cls.factors_allowed() and not cls.weights_allowed():
+            if not factors and not weights:
                 raise TypeError(f"Class `{cls.__name__}` cannot be used for factors or weights.")
+        cls.__prior_factors_allowed__ = factors
+        cls.__prior_weights_allowed__ = weights
         super().__init_subclass__(**kwargs)
 
     def __init__(self, names: str | Sequence[str]):
@@ -102,12 +104,12 @@ class Prior(
     @classmethod
     def factors_allowed(cls):
         """`True` if this prior can be used for factors."""
-        return getattr(cls, "_factors", True)
+        return cls.__prior_factors_allowed__
 
     @classmethod
     def weights_allowed(cls):
         """`True` if this prior can be used for weights."""
-        return getattr(cls, "_weights", True)
+        return cls.__prior_weights_allowed__
 
     @property
     def names(self) -> tuple[str]:

--- a/src/mofaflex/_core/priors/base.py
+++ b/src/mofaflex/_core/priors/base.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from enum import Enum, auto
+from dataclasses import dataclass
 from inspect import isabstract
 from types import MappingProxyType
-from typing import Literal, NamedTuple
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -12,35 +12,39 @@ import torch
 from numpy.typing import NDArray
 from pyro.nn import PyroModule, pyro_method
 
+from ..api.utils import DynamicAPI, DynamicAPIDecorator, DynamicAPIMixin
 from ..datasets import MofaFlexDataset
 from ..utils import MeanStd, PyroMeta, SaveStateMixin, checked_baseclass
 
 
-class APIType(Enum):
-    method = auto()
-    property = auto()
-
-
-class API(NamedTuple):
-    """Description of a user-facing API attribute."""
-
-    name: str
-    """The name of the attribute."""
-
-    type: APIType
-    """The type of the attribute (method or property)."""
-
+@dataclass(kw_only=True, frozen=True)
+class PriorDynamicAPI(DynamicAPI):
     has_factors: bool
     """Whether this attribute returns a dict of dataframes with factors."""
 
-    factors_subset: str | None
+    factors_subset: str | None = None
     """Which property of the object to which this API attribute belongs to query for the subset of factors returned
     by this attribute. Will only be used if `had_factors=True`. If `None`, it is assumed that this attribute returns
     all factors. The property must return a slice or a sequence of indices."""
 
 
+class _PriorDynamicAPIDecorator(DynamicAPIDecorator):
+    def __init__(self, func: Callable | property, **kwargs):
+        if "has_factors" not in kwargs:
+            kwargs["has_factors"] = not isinstance(func, property)
+        super().__init__(func, **kwargs)
+
+
 @checked_baseclass(required_init_args=("names"), registry="dict")
-class Prior(SaveStateMixin, ABC, PyroModule, metaclass=PyroMeta):
+class Prior(
+    DynamicAPIMixin,
+    SaveStateMixin,
+    ABC,
+    PyroModule,
+    metaclass=PyroMeta,
+    dynapi_cls=PriorDynamicAPI,
+    dynapi_decorator_cls=_PriorDynamicAPIDecorator,
+):
     """Base class for MOFA-FLEX factors and weights priors.
 
     Subclasses can eiher implement `_model` and `_guide`, or reimplment `model` and `guide`. The former set of methods
@@ -53,12 +57,30 @@ class Prior(SaveStateMixin, ABC, PyroModule, metaclass=PyroMeta):
     This base class provides default behavior for simple usecases, Subclasses can reimplement any combination of
     methods to customize aspects. Subclasses can also contain two boolean attributs:
 
-        - `_factors`: Indicates whether the subclass is suitable for factors.
-        - `_weights`: Indicates whether the subclass is suitable for weights.
+    - `_factors`: Indicates whether the subclass is suitable for factors.
+    - `_weights`: Indicates whether the subclass is suitable for weights.
 
     By default, it is assumed that a subclass is suitable for both factors and weights. Generally, specifying these attributes
     should only be necessary if a prior is not suitable for either factors or weights and no wrapper class in _core/priors
     exists.
+
+    Subclasses can use this to expose properties or methods to the end user through the main model class.
+    If a prior can be used for both factors and weights, the method or property name should contain `a̲x̲i̲s̲`
+    (that is the word `axis` with each letter followed by the unicode character U+0332 COMBINING LOW LINE).
+    The user-facing method/property will have this replaced by `factor` or `weight` as appropriate.
+
+    Subclasses can use the `Prior._api` decorator to mark a method or property as user-facing. The decorator accepts
+    two keyword arguments:
+
+    - has_factors: Whether the method/property returns a dict of dataframes with factors. If `True`,
+      the user-facing method will have an additional argument `ordered`, which affects whether
+      the factors in the dataframes will be ordered by explained variance or not. For this to work,
+      the factors must be in the columns. Defaults to `True` for methods and `False` for properties.
+      A property with `has_factors=True` will be wrapped in a getter method.
+    - factors_subset: Name of a property of the subclass that returns something that can be used to index a list
+      or NumPy array. If `has_factors=True` and the decorated method returns only a subset of factors, this
+      property must return the indices of the factors returned by the decorated method. Ignored with
+      `has_factors=False`.
 
     Args:
         names: The names of the groups/views that the prior is responsible for.
@@ -71,6 +93,7 @@ class Prior(SaveStateMixin, ABC, PyroModule, metaclass=PyroMeta):
         if not isabstract(cls) and cls.__name__[0] != "_":
             if not cls.factors_allowed() and not cls.weights_allowed():
                 raise TypeError(f"Class `{cls.__name__}` cannot be used for factors or weights.")
+        super().__init_subclass__(**kwargs)
 
     def __init__(self, names: str | Sequence[str]):
         super().__init__()
@@ -90,73 +113,6 @@ class Prior(SaveStateMixin, ABC, PyroModule, metaclass=PyroMeta):
     def names(self) -> tuple[str]:
         """The names of the groups/views that the prior is responsible for."""
         return self._names
-
-    @staticmethod
-    def _api(  # noqa: D417
-        obj: Callable | property | None = None, *, has_factors: bool | None = None, factors_subset: str | None = None
-    ):
-        """Mark a method or property as user-facing.
-
-        Subclasses can use this to expose properties or methods to the end user through the main model class.
-        If a prior can be used for both factors and weights, the method or property name should contain `a̲x̲i̲s̲`
-        (that is the word `axis` with each letter followed by the unicode character U+0332 COMBINING LOW LINE).
-        The user-facing method/property will have this replaced by `factor` or `weight` as appropriate.
-
-        Args:
-            has_factors: Whether the method/property returns a dict of dataframes with factors. If `True`,
-                the user-facing method will have an additional argument `ordered`, which affects whether
-                the factors in the dataframes will be ordered by explained variance or not. For this to work,
-                the factors must be in the columns. Defaults to `True` for methods and `False` for properties.
-                A property with `has_factors=True` will be wrapped in a getter method.
-            factors_subset: Name of a property of the subclass that returns something that can be used to index a list
-                or NumPy array. If `has_factors=True` and the decorated method returns only a subset of factors, this
-                property must return the indices of the factors returned by the decorated method. Ignored with
-                `has_factors=False`.
-        """
-
-        class __api:
-            @staticmethod
-            def _add_api(owner, api: API):
-                if "_apilist" not in owner.__dict__:
-                    owner._apilist = owner._apilist.copy()
-                owner._apilist.append(api)
-
-            def __init__(self, func: Callable | property):
-                self._func = func
-
-            def __set_name__(self, owner, name: str):
-                if isinstance(self._func, Callable):
-                    self._add_api(
-                        owner,
-                        API(name, APIType.method, has_factors if has_factors is not None else True, factors_subset),
-                    )
-                else:
-                    self._add_api(
-                        owner,
-                        API(name, APIType.property, has_factors if has_factors is not None else False, factors_subset),
-                    )
-                    self._func.__set_name__(owner, name)
-                setattr(owner, name, self._func)
-
-        if obj is not None:
-            return __api(obj)
-        else:
-            return __api
-
-    @classmethod
-    def api(cls) -> Sequence[API]:
-        """The user-facing API of this prior."""
-        return cls._apilist
-
-    @classmethod
-    def api_methods(cls) -> Iterable[API]:
-        """The user-facing methods of this prior."""
-        return (api for api in cls._apilist if api.type == APIType.method)
-
-    @classmethod
-    def api_properties(cls) -> Iterable[API]:
-        """The user-facing properties of this prior."""
-        return (api for api in cls._apilist if api.type == APIType.property)
 
     def get_datasets(
         self, data: MofaFlexDataset, axis: Literal[0, 1], n_factors: int, n_nonfactors: Mapping[str, int]

--- a/src/mofaflex/_core/priors/gsfa.py
+++ b/src/mofaflex/_core/priors/gsfa.py
@@ -18,7 +18,7 @@ from ..utils import MeanStd, PyroParameterDict
 from .base import Prior
 
 
-class GSFA(Prior):
+class GSFA(Prior, weights=False):
     """Guided sparse factor analysis prior for CRISPR perturbation screens.
 
     Args:
@@ -26,7 +26,6 @@ class GSFA(Prior):
         s_b: The $s_b$ parameter for the hyperprior on the non-zero probability.
     """
 
-    _weights = False
     _state_attrs = ("_targets_obsm_key", "_s_b", "_targets", "_probabilities", "_precisions", "_beta")
 
     def __init__(self, names: str | Sequence[str], targets_obsm_key: str, s_b: float = 20):

--- a/src/mofaflex/_core/priors/horseshoe.py
+++ b/src/mofaflex/_core/priors/horseshoe.py
@@ -136,7 +136,7 @@ class Horseshoe(Prior):
         return posteriors
 
 
-class InformedHorseshoe(Horseshoe):
+class InformedHorseshoe(Horseshoe, factors=False):
     """Horseshoe prior with domain knowledge.
 
     Args:
@@ -146,8 +146,6 @@ class InformedHorseshoe(Horseshoe):
             training, while larger values encourage the model to more closely adhere to the provided annotations.
     """
 
-    _factors = False
-    _weights = True
     _state_attrs = (
         "_annotation_confidence",
         "_annotations_varm_key",

--- a/src/mofaflex/_core/terms/base.py
+++ b/src/mofaflex/_core/terms/base.py
@@ -16,7 +16,7 @@ from ..utils import PyroMeta, SaveStateMixin, checked_baseclass
 
 
 @checked_baseclass(registry="dict")
-class Term(SaveStateMixin, DynamicAPIMixin, ABC, PyroModule, metaclass=PyroMeta):
+class Term(DynamicAPIMixin, SaveStateMixin, ABC, PyroModule, metaclass=PyroMeta):
     r"""Base class for MOFA-FLEX additive terms.
 
     A Term represents one additive contribution to the generative model, i.e. a component of the form:

--- a/src/mofaflex/_core/terms/mofaflex.py
+++ b/src/mofaflex/_core/terms/mofaflex.py
@@ -23,9 +23,10 @@ from scipy.sparse import issparse
 from sklearn.decomposition import NMF, PCA
 
 from ..api import priors as apipriors
+from ..api.utils import APIType
 from ..datasets import CovariatesDataset, MofaFlexDataset, StackDataset, df_to_array, merge_covariates
 from ..likelihoods.pyro import Likelihood
-from ..priors import API, APIType, FactorPriorType, Prior, WeightPriorType
+from ..priors import FactorPriorType, Prior, PriorDynamicAPI, WeightPriorType
 from ..utils import MeanStd, PyroModuleDict, PyroParameterDict, change_pyro_plate_dim, default_torch_device
 from .base import Term
 
@@ -133,7 +134,7 @@ class MofaFlex(Term):
             )
         return ret
 
-    def _wrap_api_method(self, axis: Literal[0, 1], prior: Prior, api: API):
+    def _wrap_api_method(self, axis: Literal[0, 1], prior: Prior, api: PriorDynamicAPI):
         def wrapper_func(self, *args, **kwargs):
             with torch.device(self._device):
                 ret = getattr(prior, api.name)
@@ -900,7 +901,7 @@ def _init_api():
                     attr = property(make_dummy_function(name, prior, True))
                     attr.__doc__ = getattr(priorcls, api.name).__doc__
                     setattr(MofaFlex, name, attr)
-                    Term._api(MofaFlex, name, hidden=True)
+                    MofaFlex._api(name, hidden=True)
                     continue
 
                 func = getattr(priorcls, api.name)
@@ -928,7 +929,7 @@ def _init_api():
                     wrapperfunc.__name__ = name
 
                 setattr(MofaFlex, name, wrapperfunc)
-                Term._api(MofaFlex, name, hidden=True)
+                MofaFlex._api(name, hidden=True)
 
             postprocess_method = priorcls.postprocess_results
             params = [

--- a/src/mofaflex/_core/utils.py
+++ b/src/mofaflex/_core/utils.py
@@ -67,9 +67,13 @@ def checked_baseclass(
         subinitcls = cls.__dict__.get("__init_subclass__", None)
 
         def init_subclass(subcls, **kwargs):
-            super(cls).__init_subclass__(**kwargs)
             if subinitcls is not None:
                 subinitcls.__get__(subcls, subcls)(**kwargs)
+            else:
+                try:
+                    super(cls).__init_subclass__(**kwargs)
+                except TypeError():
+                    super(cls).__init_subclass__()
             if not isabstract(subcls) and subcls.__name__[0] != "_":
                 init_sig = signature(subcls.__init__)
                 for i, (required_arg, param) in enumerate(

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from mofaflex._core.priors import APIType, Normal, Prior
+from mofaflex._core.api.utils import APIType
+from mofaflex._core.priors import Normal, Prior
 from mofaflex._core.terms import MofaFlex, mofaflex
 from mofaflex._core.utils import MeanStd
 


### PR DESCRIPTION
Until now we had two implementations of the dynamic API decorator: A generic one used by terms and likelhoods, and a specialized one for priors that stored some extra information and had a slightly different behavior. 0df8b4c changed the generic implementation to also store extra info, so it doesn't make sense to have two implementations anymore.