### PR TITLE
R2: use fraction of deviance explained for nonnegative views

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -432,3 +432,28 @@ https://github.com/microsoft/ReinMax.
 	x-fetchedfrom = {PubMed},
 	year = {2023}
 }
+
+@article{10.2307/45118439,
+	abstract = {The coefficient of determination, a.k.a. R², is well-defined in linear regression models, and measures the proportion of variation in the dependent variable explained by the predictors included in the model. To extend it for generalized linear models, we use the variance function to define the total variation of the dependent variable, as well as the remaining variation of the dependent variable after modeling the predictive effects of the independent variables. Unlike other definitions that demand complete specification of the likelihood function, our definition of R² only needs to know the mean and variance functions, so applicable to more general quasi-models. It is consistent with the classical measure of uncertainty using variance, and reduces to the classical definition of the coefficient of determination when linear regression models are considered.},
+	author = {Zhang, Dabao},
+	doi = {10.2307/45118439},
+	issn = {00031305, 15372731},
+	journal = {The American Statistician},
+	number = {4},
+	pages = {310–316},
+	publisher = {[American Statistical Association, Taylor \& Francis, Ltd.]},
+	title = {{A Coefficient of Determination for Generalized Linear Models}},
+	volume = {71},
+	x-fetchedfrom = {JSTOR},
+	year = {2017}
+}
+@book{hastie2015,
+	author = {Hastie, Trevor and Tibshirani, Robert and Wainwright, Martin},
+	doi = {10.1201/b18401},
+	isbn = {9780429171581},
+	location = {New York},
+	month = {May},
+	publisher = {Chapman and Hall/CRC},
+	title = {Statistical Learning with Sparsity: The Lasso and Generalizations},
+	year = {2015}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "h5py",
   "mizani",
   "mudata>=0.3.2",
-  "numpy",
+  "numpy>=2",
   "packaging",
   "pandas>=2.2",
   "platformdirs",

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -183,18 +183,28 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
 
     @abstractmethod
     def _deviance_explained_impl(
-        self, y_true: Matrix[np.number], y_pred: Matrix[np.floating], alignment_idx: Vector[int], group_name: str
+        self,
+        y_true: Matrix[np.number],
+        y_pred: Matrix[np.floating],
+        group_name: str,
+        sample_idx: Vector[int] | slice = slice(None),
+        feature_idx: Vector[int] | slice = slice(None),
     ) -> R2 | LogLikelihoods:
         """Implementation of fraction of deviance explained calculation..
 
         When `self._nonnegative` is `True`, this is used to calculate the fraction of deviance explained instead of the usual
         R2. Fraction of deviance explained is defined in Hastie, Tibsihirani, Wainwright: Statistical Learning with Sparsity (CRC Press, 2015).
 
+        In contrast to `_r2_impl`, the prediction is passed untransformed, i.e. it is the raw linear predictor. Applying
+        the inverse link (or using the linear predictor directly, if the log-likelihood is parameterized by it) is up to
+        the implementation.
+
         Args:
             y_true: The observed data.
             y_pred: The predicted data, untransformed.
-            alignment_idx: Index to use for subsetting arrays aligned to global features in order to align them to local features.
             group_name: The group name.
+            sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
+            feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
 
         Returns:
             Either an R2 object with the claculated fraction, or a LogLikelihoods object with the three required log-likelihoods, in which case the
@@ -253,6 +263,10 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             group_name: The group name.
             sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
             feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
+
+        Raises:
+            ValueError: If the deviance of the null model is not finite or is zero while the deviance of the model
+                is not, or if the deviance of the model is NaN.
         """
         if not self._nonnegative:
             r2 = self._r2_impl(
@@ -266,6 +280,18 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             r2 = self._deviance_explained_impl(y_true, y_pred, group_name, sample_idx, feature_idx)
             if isinstance(r2, LogLikelihoods):
                 r2 = R2(r2.saturated - r2.model, r2.saturated - r2.null)
+
+        # without this, max() silently turns a NaN into a plausible-looking 0. An infinite null deviance would make
+        # every model look like a perfect fit. An infinite residual deviance, on the other hand, is meaningful: the
+        # model is infinitely worse than the null model, which the clamp below turns into 0.
+        if np.isnan(r2.ss_res) or not np.isfinite(r2.ss_tot) or (r2.ss_tot == 0 and r2.ss_res != 0):
+            raise ValueError(
+                f"Cannot calculate R2 for view {self._view_name} in group {group_name}: "
+                f"ss_res={r2.ss_res}, ss_tot={r2.ss_tot}."
+            )
+        if r2.ss_tot == 0:
+            # the null model is a perfect fit and nothing is left to explain, e.g. for a group with a single sample
+            return 0.0
         return max(0.0, 1.0 - r2.ss_res / r2.ss_tot)
 
     def _load(self, state: Mapping[str, Any], feature_names: Vector[str], **kwargs):

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -175,7 +175,7 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
 
         Args:
             y_true: The observed data.
-            y_pred: The predicted data.
+            y_pred: The predicted data, transformed by self.transform_prediction..
             alignment_idx: Index to use for subsetting arrays aligned to global features in order to align them to local features.
             group_name: The group name.
         """
@@ -192,7 +192,7 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
 
         Args:
             y_true: The observed data.
-            y_pred: The predicted data.
+            y_pred: The predicted data, untransformed.
             alignment_idx: Index to use for subsetting arrays aligned to global features in order to align them to local features.
             group_name: The group name.
 
@@ -254,9 +254,14 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
             feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
         """
-        y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
         if not self._nonnegative:
-            r2 = self._r2_impl(y_true, y_pred, group_name, sample_idx, feature_idx)
+            r2 = self._r2_impl(
+                y_true,
+                self.transform_prediction(y_pred, group_name, sample_idx, feature_idx),
+                group_name,
+                sample_idx,
+                feature_idx,
+            )
         else:
             r2 = self._deviance_explained_impl(y_true, y_pred, group_name, sample_idx, feature_idx)
             if isinstance(r2, LogLikelihoods):

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -264,9 +264,8 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
             feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
 
-        Raises:
-            ValueError: If the deviance of the null model is not finite or is zero while the deviance of the model
-                is not, or if the deviance of the model is NaN.
+        Returns:
+            The fraction of explained variance, or NaN if it is undefined, e.g. if the null model has zero deviance.
         """
         if not self._nonnegative:
             r2 = self._r2_impl(
@@ -281,18 +280,9 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             if isinstance(r2, LogLikelihoods):
                 r2 = R2(r2.saturated - r2.model, r2.saturated - r2.null)
 
-        # without this, max() silently turns a NaN into a plausible-looking 0. An infinite null deviance would make
-        # every model look like a perfect fit. An infinite residual deviance, on the other hand, is meaningful: the
-        # model is infinitely worse than the null model, which the clamp below turns into 0.
-        if np.isnan(r2.ss_res) or not np.isfinite(r2.ss_tot) or (r2.ss_tot == 0 and r2.ss_res != 0):
-            raise ValueError(
-                f"Cannot calculate R2 for view {self._view_name} in group {group_name}: "
-                f"ss_res={r2.ss_res}, ss_tot={r2.ss_tot}."
-            )
-        if r2.ss_tot == 0:
-            # the null model is a perfect fit and nothing is left to explain, e.g. for a group with a single sample
-            return 0.0
-        return max(0.0, 1.0 - r2.ss_res / r2.ss_tot)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            # np.max, in contrast to max, preserves NaNs, which the caller warns about
+            return np.max((0.0, 1.0 - np.divide(r2.ss_res, r2.ss_tot)))
 
     def _load(self, state: Mapping[str, Any], feature_names: Vector[str], **kwargs):
         self._feature_names = feature_names

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -22,6 +22,12 @@ class R2(NamedTuple):
     ss_tot: float
 
 
+class LogLikelihoods(NamedTuple):
+    saturated: float
+    null: float
+    model: float
+
+
 @checked_baseclass(
     required_init_args=("view_name", "data", "nonnegative"), required_attributes="_priority", registry="dict"
 )
@@ -176,6 +182,27 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
         pass
 
     @abstractmethod
+    def _deviance_explained_impl(
+        self, y_true: Matrix[np.number], y_pred: Matrix[np.floating], alignment_idx: Vector[int], group_name: str
+    ) -> R2 | LogLikelihoods:
+        """Implementation of fraction of deviance explained calculation..
+
+        When `self._nonnegative` is `True`, this is used to calculate the fraction of deviance explained instead of the usual
+        R2. Fraction of deviance explained is defined in Hastie, Tibsihirani, Wainwright: Statistical Learning with Sparsity (CRC Press, 2015).
+
+        Args:
+            y_true: The observed data.
+            y_pred: The predicted data.
+            alignment_idx: Index to use for subsetting arrays aligned to global features in order to align them to local features.
+            group_name: The group name.
+
+        Returns:
+            Either an R2 object with the claculated fraction, or a LogLikelihoods object with the three required log-likelihoods, in which case the
+            fraction will be calculated automatically..
+        """
+        pass
+
+    @abstractmethod
     def transform_prediction(
         self,
         prediction: Matrix[np.floating],
@@ -227,13 +254,13 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
             feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
         """
-        r2 = self._r2_impl(
-            y_true,
-            self.transform_prediction(y_pred, group_name, sample_idx, feature_idx),
-            group_name,
-            sample_idx,
-            feature_idx,
-        )
+        y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
+        if not self._nonnegative:
+            r2 = self._r2_impl(y_true, y_pred, group_name, sample_idx, feature_idx)
+        else:
+            r2 = self._deviance_explained_impl(y_true, y_pred, group_name, sample_idx, feature_idx)
+            if isinstance(r2, LogLikelihoods):
+                r2 = R2(r2.saturated - r2.model, r2.saturated - r2.null)
         return max(0.0, 1.0 - r2.ss_res / r2.ss_tot)
 
     def _load(self, state: Mapping[str, Any], feature_names: Vector[str], **kwargs):

--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -169,15 +169,21 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
 
     @abstractmethod
     def _r2_impl(
-        self, y_true: Matrix[np.number], y_pred: Matrix[np.floating], alignment_idx: Vector[int], group_name: str
+        self,
+        y_true: Matrix[np.number],
+        y_pred: Matrix[np.floating],
+        group_name: str,
+        sample_idx: Vector[int] | slice = slice(None),
+        feature_idx: Vector[int] | slice = slice(None),
     ) -> R2:
         """Implementation of R2 calculation.
 
         Args:
             y_true: The observed data.
             y_pred: The predicted data, transformed by self.transform_prediction..
-            alignment_idx: Index to use for subsetting arrays aligned to global features in order to align them to local features.
             group_name: The group name.
+            sample_idx: The sample indices of the prediction, if only a subset of samples were predicted.
+            feature_idx: The feature indices of the prediction, if only a subset of features were predicted.
         """
         pass
 
@@ -280,9 +286,8 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             if isinstance(r2, LogLikelihoods):
                 r2 = R2(r2.saturated - r2.model, r2.saturated - r2.null)
 
-        with np.errstate(invalid="ignore", divide="ignore"):
-            # np.max, in contrast to max, preserves NaNs, which the caller warns about
-            return np.max((0.0, 1.0 - np.divide(r2.ss_res, r2.ss_tot)))
+        # np.max, in contrast to max, preserves NaNs, which the caller warns about
+        return np.max((0.0, 1.0 - np.divide(r2.ss_res, r2.ss_tot)))
 
     def _load(self, state: Mapping[str, Any], feature_names: Vector[str], **kwargs):
         self._feature_names = feature_names

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -4,7 +4,7 @@ from scipy.special import expit, logit
 
 from ..datasets import MofaFlexDataset
 from ..settings import settings
-from ..utils import Matrix, Vector, nanmean, nanmin
+from ..utils import Matrix, Vector, nanmean
 from .base import R2, Likelihood
 from .pyro import Bernoulli as PyroBernoulli
 from .pyro import Likelihood as PyroLikelihood
@@ -79,8 +79,7 @@ class Bernoulli(Likelihood):
     ) -> R2:
         # the shift is part of the linear predictor, see transform_prediction
         shift = self._shift[group_name][feature_idx]
-        null_probability = np.clip(nanmin(y_true, axis=0), settings.eps, 1 - settings.eps)
-        loglik_null = np.nansum(self._logpmf(y_true, logit(null_probability)))
+        loglik_null = np.nansum(self._logpmf(y_true, shift))
         loglik_model = np.nansum(self._logpmf(y_true, y_pred + shift))
 
         # saturated model has deviance 0

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -5,7 +5,7 @@ from scipy.special import expit, logit
 from ..datasets import MofaFlexDataset
 from ..settings import settings
 from ..utils import Matrix, Vector, nanmean
-from .base import R2, Likelihood, LogLikelihoods
+from .base import R2, Likelihood
 from .pyro import Bernoulli as PyroBernoulli
 from .pyro import Likelihood as PyroLikelihood
 
@@ -76,9 +76,11 @@ class Bernoulli(Likelihood):
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
-    ) -> LogLikelihoods:
-        loglik_null = np.nansum(self._logpmf(y_true, self._shift[group_name][feature_idx]))
-        loglik_model = np.nansum(self._logpmf(y_true, y_pred))
+    ) -> R2:
+        # the shift is part of the linear predictor, see transform_prediction
+        shift = self._shift[group_name][feature_idx]
+        loglik_null = np.nansum(self._logpmf(y_true, shift))
+        loglik_model = np.nansum(self._logpmf(y_true, y_pred + shift))
 
         # saturated model has deviance 0
         return R2(loglik_model, loglik_null)

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -72,11 +72,11 @@ class Bernoulli(Likelihood):
     ) -> LogLikelihoods:
         truemean = expit(self._shift[group_name][feature_idx])
 
-        loglik_saturated = bernoulli.logpmf(y_true, y_true).sum()
         loglik_null = bernoulli.logpmf(y_true, truemean).sum()
         loglik_model = bernoulli.logpmf(y_true, y_pred).sum()
 
-        return LogLikelihoods(loglik_saturated, loglik_null, loglik_model)
+        # saturated model has deviance 0
+        return R2(loglik_model, loglik_null)
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -4,7 +4,7 @@ from scipy.special import expit, logit
 
 from ..datasets import MofaFlexDataset
 from ..settings import settings
-from ..utils import Matrix, Vector, nanmean
+from ..utils import Matrix, Vector, nanmean, nanmin
 from .base import R2, Likelihood
 from .pyro import Bernoulli as PyroBernoulli
 from .pyro import Likelihood as PyroLikelihood
@@ -79,7 +79,8 @@ class Bernoulli(Likelihood):
     ) -> R2:
         # the shift is part of the linear predictor, see transform_prediction
         shift = self._shift[group_name][feature_idx]
-        loglik_null = np.nansum(self._logpmf(y_true, shift))
+        null_probability = np.clip(nanmin(y_true, axis=0), settings.eps, 1 - settings.eps)
+        loglik_null = np.nansum(self._logpmf(y_true, logit(null_probability)))
         loglik_model = np.nansum(self._logpmf(y_true, y_pred + shift))
 
         # saturated model has deviance 0

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 from anndata import AnnData
 from scipy.special import expit, logit
@@ -8,6 +10,8 @@ from ..utils import Matrix, Vector, nanmean
 from .base import R2, Likelihood
 from .pyro import Bernoulli as PyroBernoulli
 from .pyro import Likelihood as PyroLikelihood
+
+_logger = logging.getLogger(__name__)
 
 
 class Bernoulli(Likelihood):
@@ -30,6 +34,11 @@ class Bernoulli(Likelihood):
                 self._calc_shift(adata), group_name, self._view_name, align_to="features"
             ),
         )
+
+        if nonnegative:
+            _logger.warning(
+                "The Bernoulli likelihood does not support nonnegative views. Your results may be suboptimal."
+            )
 
     def _get_pyro_likelihood(self, data: MofaFlexDataset, sample_dim: int, feature_dim: int) -> PyroLikelihood:
         return PyroBernoulli(

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -77,8 +77,8 @@ class Bernoulli(Likelihood):
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
     ) -> LogLikelihoods:
-        loglik_null = self._logpmf(y_true, self._shift[group_name][feature_idx]).sum()
-        loglik_model = self._logpmf(y_true, y_pred).sum()
+        loglik_null = np.nansum(self._logpmf(y_true, self._shift[group_name][feature_idx]))
+        loglik_model = np.nansum(self._logpmf(y_true, y_pred))
 
         # saturated model has deviance 0
         return R2(loglik_model, loglik_null)

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -1,11 +1,12 @@
 import numpy as np
 from anndata import AnnData
 from scipy.special import expit, logit
+from scipy.stats import bernoulli
 
 from ..datasets import MofaFlexDataset
 from ..settings import settings
 from ..utils import Matrix, Vector, nanmean
-from .base import R2, Likelihood
+from .base import R2, Likelihood, LogLikelihoods
 from .pyro import Bernoulli as PyroBernoulli
 from .pyro import Likelihood as PyroLikelihood
 
@@ -60,6 +61,22 @@ class Bernoulli(Likelihood):
         ss_res = np.nansum(self._dV_square(y_true, y_pred, -1, 1))
         ss_tot = np.nansum(self._dV_square(y_true, expit(self._shift[group_name][feature_idx]), -1, 1))
         return R2(ss_res, ss_tot)
+
+    def _deviance_explained_impl(
+        self,
+        y_true: Matrix[np.number],
+        y_pred: Matrix[np.floating],
+        group_name: str,
+        sample_idx: Vector[int] | slice = slice(None),
+        feature_idx: Vector[int] | slice = slice(None),
+    ) -> LogLikelihoods:
+        truemean = expit(self._shift[group_name][feature_idx])
+
+        loglik_saturated = bernoulli.logpmf(y_true, y_true).sum()
+        loglik_null = bernoulli.logpmf(y_true, truemean).sum()
+        loglik_model = bernoulli.logpmf(y_true, y_pred).sum()
+
+        return LogLikelihoods(loglik_saturated, loglik_null, loglik_model)
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -1,7 +1,6 @@
 import numpy as np
 from anndata import AnnData
 from scipy.special import expit, logit
-from scipy.stats import bernoulli
 
 from ..datasets import MofaFlexDataset
 from ..settings import settings
@@ -62,6 +61,14 @@ class Bernoulli(Likelihood):
         ss_tot = np.nansum(self._dV_square(y_true, expit(self._shift[group_name][feature_idx]), -1, 1))
         return R2(ss_res, ss_tot)
 
+    @staticmethod
+    def _logpmf(y, logits):
+        m1 = np.maximum(0, -logits)
+        m2 = np.maximum(0, logits)
+        return -y * (m1 + np.log(np.exp(0 - m1) + np.exp(-logits - m1))) - (1 - y) * (
+            m2 + np.log(np.exp(0 - m2) + np.exp(logits - m2))
+        )
+
     def _deviance_explained_impl(
         self,
         y_true: Matrix[np.number],
@@ -70,10 +77,8 @@ class Bernoulli(Likelihood):
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
     ) -> LogLikelihoods:
-        truemean = expit(self._shift[group_name][feature_idx])
-
-        loglik_null = bernoulli.logpmf(y_true, truemean).sum()
-        loglik_model = bernoulli.logpmf(y_true, y_pred).sum()
+        loglik_null = self._logpmf(y_true, self._shift[group_name][feature_idx]).sum()
+        loglik_model = self._logpmf(y_true, y_pred).sum()
 
         # saturated model has deviance 0
         return R2(loglik_model, loglik_null)

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -82,6 +82,12 @@ class NegativeBinomial(Likelihood):
 
         return R2(ss_res, ss_tot)
 
+    def _logpmf(
+        self, y_true: Matrix[np.number], mean: Matrix[np.floating], feature_idx: Vector[int] | slice = slice(None)
+    ) -> Matrix[np.floating]:
+        dispersion = self._dispersion.mean[feature_idx]
+        return nbinom.logpmf(y_true, p=1 / (1 + dispersion * mean), n=1 / (dispersion + settings.eps))
+
     def _deviance_explained_impl(
         self,
         y_true: Matrix[np.number],
@@ -91,32 +97,19 @@ class NegativeBinomial(Likelihood):
         feature_idx: Vector[int] | slice = slice(None),
     ) -> LogLikelihoods:
         y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
-        truemean = self._shift[group_name][feature_idx]
-        variance = np.nanvar(y_true, axis=0, mean=truemean)
 
-        # use estimated dispersion for saturated model
-        # naive variance is most likely overestimated since the minimum of the data is used instead of the mean
-        loglik_saturated = np.nansum(
-            nbinom.logpmf(
-                y_true,
-                p=1 / (1 + self._dispersion.mean[feature_idx] * y_true),
-                n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
-            )
-        )
-        loglik_null = np.nansum(
-            nbinom.logpmf(
-                y_true,
-                p=np.clip(truemean / variance, settings.eps, 1 - settings.eps),
-                n=np.maximum(settings.eps, truemean**2 / np.maximum(settings.eps, variance - truemean)),
-            )
-        )
-        loglik_model = np.nansum(
-            nbinom.logpmf(
-                y_true,
-                p=1 / (1 + self._dispersion.mean[feature_idx] * y_pred),
-                n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
-            )
-        )
+        # the null model is the feature-wise mean on the size factor-normalized scale. self._shift is the feature-wise
+        # minimum for nonnegative views, which is 0 for virtually every count feature and would make the null degenerate.
+        sample_means = self._sample_means[group_name][sample_idx]
+        with np.errstate(invalid="ignore"):
+            # samples without any counts have a sample mean of 0, so the division is 0/0. Their null mean is 0
+            # regardless of the result, and they contribute nothing to any of the log-likelihoods.
+            null_mean = nanmean(y_true / sample_means, axis=0) * sample_means
+
+        # use the estimated dispersion for all three models, otherwise the log-likelihoods are not comparable
+        loglik_saturated = np.nansum(self._logpmf(y_true, y_true, feature_idx))
+        loglik_null = np.nansum(self._logpmf(y_true, null_mean, feature_idx))
+        loglik_model = np.nansum(self._logpmf(y_true, y_pred, feature_idx))
 
         return LogLikelihoods(loglik_saturated, loglik_null, loglik_model)
 

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -90,6 +90,7 @@ class NegativeBinomial(Likelihood):
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
     ) -> LogLikelihoods:
+        y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
         truemean = self._shift[group_name][feature_idx]
         variance = np.nanvar(y_true, axis=0, mean=truemean)
 

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -101,7 +101,11 @@ class NegativeBinomial(Likelihood):
             p=1 / (1 + self._dispersion.mean[feature_idx] * y_true),
             n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
         ).sum()
-        loglik_null = nbinom.logpmf(y_true, p=truemean / variance, n=truemean**2 / (variance - truemean)).sum()
+        loglik_null = nbinom.logpmf(
+            y_true,
+            p=np.clip(truemean / variance, settings.eps, 1 - settings.eps),
+            n=np.maximum(settings.eps, truemean**2 / np.maximum(settings.eps, variance - truemean)),
+        ).sum()
         loglik_model = nbinom.logpmf(
             y_true,
             p=1 / (1 + self._dispersion.mean[feature_idx] * y_pred),

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -98,13 +98,9 @@ class NegativeBinomial(Likelihood):
     ) -> LogLikelihoods:
         y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
 
-        # the null model is the feature-wise mean on the size factor-normalized scale. self._shift is the feature-wise
-        # minimum for nonnegative views, which is 0 for virtually every count feature and would make the null degenerate.
+        # the null model is the feature-wise minimum on the size factor-normalized scale
         sample_means = self._sample_means[group_name][sample_idx]
-        with np.errstate(invalid="ignore"):
-            # samples without any counts have a sample mean of 0, so the division is 0/0. Their null mean is 0
-            # regardless of the result, and they contribute nothing to any of the log-likelihoods.
-            null_mean = nanmean(y_true / sample_means, axis=0) * sample_means
+        null_mean = np.maximum(self._shift[group_name][feature_idx], settings.eps) * sample_means
 
         # use the estimated dispersion for all three models, otherwise the log-likelihoods are not comparable
         loglik_saturated = np.nansum(self._logpmf(y_true, y_true, feature_idx))

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -2,10 +2,12 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from scipy.stats import nbinom
 
 from ..datasets import MofaFlexDataset
+from ..settings import settings
 from ..utils import Matrix, Vector, nanmean, nanmin
-from .base import R2, Likelihood
+from .base import R2, Likelihood, LogLikelihoods
 from .pyro import Likelihood as PyroLikelihood
 from .pyro import NegativeBinomial as PyroNegativeBinomial
 
@@ -66,7 +68,7 @@ class NegativeBinomial(Likelihood):
 
     def _r2_impl(
         self,
-        y_true: Matrix,
+        y_true: Matrix[np.number],
         y_pred: Matrix[np.floating],
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
@@ -79,6 +81,33 @@ class NegativeBinomial(Likelihood):
         ss_tot = np.nansum(self._dV_square(y_true, truemean, nu2, 1))
 
         return R2(ss_res, ss_tot)
+
+    def _deviance_explained_impl(
+        self,
+        y_true: Matrix[np.number],
+        y_pred: Matrix[np.floating],
+        group_name: str,
+        sample_idx: Vector[int] | slice = slice(None),
+        feature_idx: Vector[int] | slice = slice(None),
+    ) -> LogLikelihoods:
+        truemean = self._shift[group_name][feature_idx]
+        variance = np.nanvar(y_true, axis=0, mean=truemean)
+
+        # use estimated dispersion for saturated model
+        # naive variance is most likely overestimated since the minimum of the data is used instead of the mean
+        loglik_saturated = nbinom.logpmf(
+            y_true,
+            p=1 / (1 + self._dispersion.mean[feature_idx] * y_true),
+            n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
+        ).sum()
+        loglik_null = nbinom.logpmf(y_true, p=truemean / variance, n=truemean**2 / (variance - truemean)).sum()
+        loglik_model = nbinom.logpmf(
+            y_true,
+            p=1 / (1 + self._dispersion.mean[feature_idx] * y_pred),
+            n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
+        ).sum()
+
+        return LogLikelihoods(loglik_saturated, loglik_null, loglik_model)
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -96,21 +96,27 @@ class NegativeBinomial(Likelihood):
 
         # use estimated dispersion for saturated model
         # naive variance is most likely overestimated since the minimum of the data is used instead of the mean
-        loglik_saturated = nbinom.logpmf(
-            y_true,
-            p=1 / (1 + self._dispersion.mean[feature_idx] * y_true),
-            n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
-        ).sum()
-        loglik_null = nbinom.logpmf(
-            y_true,
-            p=np.clip(truemean / variance, settings.eps, 1 - settings.eps),
-            n=np.maximum(settings.eps, truemean**2 / np.maximum(settings.eps, variance - truemean)),
-        ).sum()
-        loglik_model = nbinom.logpmf(
-            y_true,
-            p=1 / (1 + self._dispersion.mean[feature_idx] * y_pred),
-            n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
-        ).sum()
+        loglik_saturated = np.nansum(
+            nbinom.logpmf(
+                y_true,
+                p=1 / (1 + self._dispersion.mean[feature_idx] * y_true),
+                n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
+            )
+        )
+        loglik_null = np.nansum(
+            nbinom.logpmf(
+                y_true,
+                p=np.clip(truemean / variance, settings.eps, 1 - settings.eps),
+                n=np.maximum(settings.eps, truemean**2 / np.maximum(settings.eps, variance - truemean)),
+            )
+        )
+        loglik_model = np.nansum(
+            nbinom.logpmf(
+                y_true,
+                p=1 / (1 + self._dispersion.mean[feature_idx] * y_pred),
+                n=1 / (self._dispersion.mean[feature_idx] + settings.eps),
+            )
+        )
 
         return LogLikelihoods(loglik_saturated, loglik_null, loglik_model)
 

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -76,9 +76,10 @@ class NegativeBinomial(Likelihood):
     ) -> R2:
         ss_res = np.nansum(self._dV_square(y_true, y_pred, self._dispersion.mean[feature_idx], 1))
 
-        truemean = self._shift[group_name][feature_idx]
-        nu2 = (np.nanvar(y_true, axis=0, mean=truemean) - truemean) / truemean**2  # method of moments estimator
-        ss_tot = np.nansum(self._dV_square(y_true, truemean, nu2, 1))
+        truemean = self._shift[group_name][feature_idx] * self._sample_means[group_name][sample_idx]
+
+        # use estimated dispersion to get R2=0 for y_pred=0
+        ss_tot = np.nansum(self._dV_square(y_true, truemean, self._dispersion.mean[feature_idx], 1))
 
         return R2(ss_res, ss_tot)
 
@@ -86,7 +87,7 @@ class NegativeBinomial(Likelihood):
         self, y_true: Matrix[np.number], mean: Matrix[np.floating], feature_idx: Vector[int] | slice = slice(None)
     ) -> Matrix[np.floating]:
         dispersion = self._dispersion.mean[feature_idx]
-        return nbinom.logpmf(y_true, p=1 / (1 + dispersion * mean), n=1 / (dispersion + settings.eps))
+        return nbinom.logpmf(y_true, p=1 / (1 + dispersion * mean + settings.eps), n=1 / dispersion)
 
     def _deviance_explained_impl(
         self,
@@ -98,9 +99,7 @@ class NegativeBinomial(Likelihood):
     ) -> LogLikelihoods:
         y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
 
-        # the null model is the feature-wise minimum on the size factor-normalized scale
-        sample_means = self._sample_means[group_name][sample_idx]
-        null_mean = np.maximum(self._shift[group_name][feature_idx], settings.eps) * sample_means
+        null_mean = self._shift[group_name][feature_idx] * self._sample_means[group_name][sample_idx]
 
         # use the estimated dispersion for all three models, otherwise the log-likelihoods are not comparable
         loglik_saturated = np.nansum(self._logpmf(y_true, y_true, feature_idx))

--- a/src/mofaflex/_core/likelihoods/normal.py
+++ b/src/mofaflex/_core/likelihoods/normal.py
@@ -109,12 +109,14 @@ class Normal(Likelihood):
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
     ) -> R2:
-        # fraction of deviance explained reduces to standard R2 for Gaussian likelihood, but the null model is the
-        # feature-wise mean, while self._shift used by _r2_impl is the feature-wise minimum for nonnegative views
-        y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
-        ss_res = np.nansum(np.square(y_true - y_pred))
-        ss_tot = np.nansum(np.square(y_true - nanmean(y_true, axis=0)))
-        return R2(ss_res, ss_tot)
+        # fraction of deviance explained reduces to standard R2 for Gaussian likelihood
+        return self._r2_impl(
+            y_true,
+            self.transform_prediction(y_pred, group_name, sample_idx, feature_idx),
+            group_name,
+            sample_idx,
+            feature_idx,
+        )
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/normal.py
+++ b/src/mofaflex/_core/likelihoods/normal.py
@@ -109,14 +109,12 @@ class Normal(Likelihood):
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
     ) -> R2:
-        # fraction of deviance explained reduces to standard R2 for Gaussian likelihood
-        return self._r2_impl(
-            y_true,
-            self.transform_prediction(y_pred, group_name, sample_idx, feature_idx),
-            group_name,
-            sample_idx,
-            feature_idx,
-        )
+        # fraction of deviance explained reduces to standard R2 for Gaussian likelihood, but the null model is the
+        # feature-wise mean, while self._shift used by _r2_impl is the feature-wise minimum for nonnegative views
+        y_pred = self.transform_prediction(y_pred, group_name, sample_idx, feature_idx)
+        ss_res = np.nansum(np.square(y_true - y_pred))
+        ss_tot = np.nansum(np.square(y_true - nanmean(y_true, axis=0)))
+        return R2(ss_res, ss_tot)
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/normal.py
+++ b/src/mofaflex/_core/likelihoods/normal.py
@@ -101,8 +101,22 @@ class Normal(Likelihood):
         ss_tot = np.nansum(np.square(y_true - self._shift[group_name][feature_idx]))
         return R2(ss_res, ss_tot)
 
-    _deviance_explained_impl = _r2_impl
-    # fraction of deviance explained reduces to standard R2 for Gaussian likelihood
+    def _deviance_explained_impl(
+        self,
+        y_true: Matrix[np.number],
+        y_pred: Matrix[np.floating],
+        group_name: str,
+        sample_idx: Vector[int] | slice = slice(None),
+        feature_idx: Vector[int] | slice = slice(None),
+    ) -> R2:
+        # fraction of deviance explained reduces to standard R2 for Gaussian likelihood
+        return self._r2_impl(
+            y_true,
+            self.transform_prediction(y_pred, group_name, sample_idx, feature_idx),
+            group_name,
+            sample_idx,
+            feature_idx,
+        )
 
     def transform_prediction(
         self,

--- a/src/mofaflex/_core/likelihoods/normal.py
+++ b/src/mofaflex/_core/likelihoods/normal.py
@@ -101,6 +101,9 @@ class Normal(Likelihood):
         ss_tot = np.nansum(np.square(y_true - self._shift[group_name][feature_idx]))
         return R2(ss_res, ss_tot)
 
+    _deviance_explained_impl = _r2_impl
+    # fraction of deviance explained reduces to standard R2 for Gaussian likelihood
+
     def transform_prediction(
         self,
         prediction: Matrix[np.floating],

--- a/src/mofaflex/_core/model.py
+++ b/src/mofaflex/_core/model.py
@@ -355,7 +355,7 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
                         }
                 if np.isnan(r2_full):
                     _logger.warning(
-                        f"R2 for view {view_name} could not be calculated, the null model has zero deviance."
+                        f"R2 for view {view_name} could not be calculated. Verify your data and configuration, or create a minimal reproducible example and report an issue."
                     )
                 elif r2_full < settings.eps:
                     _logger.warning(

--- a/src/mofaflex/_core/model.py
+++ b/src/mofaflex/_core/model.py
@@ -353,7 +353,11 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
                             )
                             for component_name, component in component_iter
                         }
-                if r2_full < settings.eps:
+                if np.isnan(r2_full):
+                    _logger.warning(
+                        f"R2 for view {view_name} could not be calculated, the null model has zero deviance."
+                    )
+                elif r2_full < settings.eps:
                     _logger.warning(
                         f"R2 for view {view_name} is 0. Adjust model parameters and/or increase the number of training epochs."
                     )

--- a/src/mofaflex/_core/mofaflex.py
+++ b/src/mofaflex/_core/mofaflex.py
@@ -460,7 +460,13 @@ class MOFAFLEX:
     def get_r2(
         self, type: Literal["total", "byterm", "term"] | None = None, ordered: bool = False, term: str | None = None
     ) -> pd.DataFrame:
-        """Get the fraction of variance explained for each view and group.
+        r"""Get the R\ :sup:`2` for each view and group.
+
+        For views that allow negative values (at least one of factors and weights can be negative), this will be the
+        fraction of variance explained, calculated using the generalized coefficient of determination :cite:p:`10.2307/45118439`.
+
+        For nonnegative views, (both factors and weights are nonnegative), this will be the fraction of deviance explained,
+        as defined in :cite:t:`hastie2015`.
 
         Args:
             type: How fine-grained the fraction of explained variance should be split up.

--- a/src/mofaflex/pl/_plotting.py
+++ b/src/mofaflex/pl/_plotting.py
@@ -483,6 +483,12 @@ def variance_explained(
 ) -> p9.ggplot:
     """Plot the fraction of variance explained per factor in each group and view.
 
+    For views that allow negative values (at least one of factors and weights can be negative), this will be the
+    fraction of variance explained, calculated using the generalized coefficient of determination :cite:p:`10.2307/45118439`.
+
+    For nonnegative views, (both factors and weights are nonnegative), this will be the fraction of deviance explained,
+    as defined in :cite:t:`hastie2015`.
+
     Args:
         model: The MOFA-FLEX model.
         group_by: The grouping to use for the plots.

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
 from scipy.special import expit
+from scipy.stats import bernoulli
 
 from mofaflex._core import MofaFlexDataset
 from mofaflex._core.likelihoods import Bernoulli, Likelihood, NegativeBinomial, Normal
@@ -138,6 +139,11 @@ class TestBernoulli:
         for group_name, group in result.items():
             for view_name, view in group.items():
                 assert np.allclose(np.nanmean(view - expit(likelihoods[view_name]._shift[group_name]), axis=0), 0)
+
+    def test_logpmf(self, rng):
+        logits = rng.standard_normal(size=1000)
+        targets = rng.binomial(1, 0.5, size=1000)
+        np.testing.assert_allclose(bernoulli.logpmf(targets, expit(logits)), Bernoulli._logpmf(targets, logits))
 
 
 class TestNegativeBinomial:

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pytest
 from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
-from scipy.special import expit
+from scipy.special import expit, logit
 from scipy.stats import bernoulli
 
+from mofaflex import settings
 from mofaflex._core import MofaFlexDataset
 from mofaflex._core.likelihoods import Bernoulli, Likelihood, NegativeBinomial, Normal
-from mofaflex._core.utils import sample_all_data_as_one_batch
+from mofaflex._core.likelihoods.base import R2, LogLikelihoods
+from mofaflex._core.utils import MeanStd, nanmean, sample_all_data_as_one_batch
 
 _sparse_arr = [csc_array, csc_matrix, csr_array, csr_matrix]
 
@@ -169,3 +171,100 @@ class TestNegativeBinomial:
                         ).mean(axis=0),
                         0,
                     )
+
+
+_group_name = "group_0"
+_view_name = "view_0"
+
+
+class TestDevianceExplained:
+    """Fixed points of the fraction of deviance explained for nonnegative views."""
+
+    @pytest.fixture(scope="class", params=[False, True], ids=["nonan", "withnan"])
+    def y_true(self, rng, likelihood, request):
+        match likelihood:
+            case "Normal":
+                arr = np.abs(rng.standard_normal(size=(50, 10)))
+            case "Bernoulli":
+                arr = rng.binomial(1, 0.3, size=(50, 10)).astype(np.float64)
+            case "NegativeBinomial":
+                # low mean, so that most features have a zero minimum, which is what breaks a shift-based null model
+                arr = rng.negative_binomial(0.5, 0.3, size=(50, 10)).astype(np.float64)
+        arr[0, 0] = 0
+        if request.param:
+            arr[rng.random(arr.shape) < 0.1] = np.nan
+        return arr
+
+    @pytest.fixture(scope="class")
+    def likelihood_obj(self, likelihood, y_true, create_adata):
+        dataset = MofaFlexDataset({_group_name: {_view_name: create_adata(y_true)}}, cast_to=None)
+        obj = Likelihood.known_likelihoods()[likelihood](_view_name, dataset, True)
+        if isinstance(obj, NegativeBinomial):
+            obj._dispersion = MeanStd(np.full(y_true.shape[1], 0.1), None)  # not trained, so set manually
+        return obj
+
+    @staticmethod
+    def _raw_prediction(obj, target):
+        """Invert transform_prediction: the raw linear predictor which predicts `target` on the scale of the data."""
+        shift = obj._shift[_group_name]
+        match obj:
+            case Normal():
+                return (target - shift) / obj._scale[_group_name]
+            case Bernoulli():
+                return logit(np.clip(target, settings.eps, 1 - settings.eps)) - shift
+            case NegativeBinomial():
+                return target / obj._sample_means[_group_name] - shift
+
+    @staticmethod
+    def _null_target(obj, y_true):
+        """The prediction of the null model, on the scale of the data."""
+        match obj:
+            case Normal():
+                return np.broadcast_to(nanmean(y_true, axis=0), y_true.shape)
+            case Bernoulli():
+                return np.broadcast_to(expit(obj._shift[_group_name]), y_true.shape)
+            case NegativeBinomial():
+                sample_means = obj._sample_means[_group_name]
+                return nanmean(y_true / sample_means, axis=0) * sample_means
+
+    @staticmethod
+    def _unclamped(obj, y_true, y_pred):
+        """The fraction of deviance explained without the clamp to nonnegative values applied by Likelihood.r2."""
+        res = obj._deviance_explained_impl(y_true, y_pred, _group_name)
+        if isinstance(res, LogLikelihoods):
+            res = R2(res.saturated - res.model, res.saturated - res.null)
+        return 1.0 - res.ss_res / res.ss_tot
+
+    def test_null_model(self, likelihood_obj, y_true):
+        y_pred = self._raw_prediction(likelihood_obj, self._null_target(likelihood_obj, y_true))
+        # the clamp in Likelihood.r2 would hide a negative value
+        assert self._unclamped(likelihood_obj, y_true, y_pred) == pytest.approx(0, abs=1e-6)
+
+    def test_saturated_model(self, likelihood_obj, y_true):
+        y_pred = self._raw_prediction(likelihood_obj, y_true)
+        assert likelihood_obj.r2(y_true, y_pred, _group_name) == pytest.approx(1, abs=1e-6)
+
+    def test_intermediate_model(self, likelihood_obj, y_true):
+        # halfway between the null and the saturated model. Guards against a degenerate null model, which makes
+        # everything score close to 1.
+        target = (self._null_target(likelihood_obj, y_true) + y_true) / 2
+        r2 = likelihood_obj.r2(y_true, self._raw_prediction(likelihood_obj, target), _group_name)
+        assert 0.05 < r2 < 0.95
+
+    @pytest.mark.parametrize(
+        "res",
+        [R2(np.nan, 1.0), R2(1.0, np.nan), R2(1.0, np.inf), R2(1.0, 0.0)],
+        ids=["nan_res", "nan_tot", "inf_tot", "zero_tot"],
+    )
+    def test_degenerate_raises(self, likelihood_obj, y_true, res, monkeypatch):
+        # a degenerate null model must not be silently turned into a plausible-looking 0 by the clamp
+        monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
+        with pytest.raises(ValueError, match="Cannot calculate R2"):
+            likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name)
+
+    @pytest.mark.parametrize("res", [R2(0.0, 0.0), R2(np.inf, 1.0)], ids=["nothing_to_explain", "inf_res"])
+    def test_degenerate_clamps(self, likelihood_obj, y_true, res, monkeypatch):
+        # the null model is a perfect fit (e.g. a group with a single sample), or the model is infinitely worse
+        # than the null model (e.g. a count of zero predicted for a nonzero observation)
+        monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
+        assert likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name) == 0

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pytest
-from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix
-from scipy.special import expit, logit
+from scipy.sparse import csc_array, csc_matrix, csr_array, csr_matrix, issparse
+from scipy.special import expit
 from scipy.stats import bernoulli
 
-from mofaflex import settings
 from mofaflex._core import MofaFlexDataset
 from mofaflex._core.likelihoods import Bernoulli, Likelihood, NegativeBinomial, Normal
 from mofaflex._core.likelihoods.base import R2, LogLikelihoods
-from mofaflex._core.utils import MeanStd, nanmin, sample_all_data_as_one_batch
+from mofaflex._core.utils import MeanStd, sample_all_data_as_one_batch
 
 _sparse_arr = [csc_array, csc_matrix, csr_array, csr_matrix]
 
@@ -80,7 +79,68 @@ def sparse_arr(group_names, view_names):
     return fundict
 
 
-class TestNormal:
+class _TestLikelihood:
+    @pytest.fixture(scope="class")
+    def y_true(self, dataset):
+        return dataset.__getitems__(sample_all_data_as_one_batch(dataset))["data"]
+
+    def test_r2(self, y_true, likelihoods, nonnegative, subtests):
+        for group_name, group in y_true.items():
+            for view_name, view in group.items():
+                if issparse(view):
+                    view = view.toarray()
+                likelihood = likelihoods[view_name]
+
+                with subtests.test("null model"):
+                    null = np.broadcast_to(0, view.shape)
+                    if nonnegative[view_name]:
+                        res = likelihood._deviance_explained_impl(view, null, group_name)
+                    else:
+                        res = likelihood._r2_impl(view, likelihood.transform_prediction(null, group_name), group_name)
+                    if isinstance(res, LogLikelihoods):
+                        res = R2(res.saturated - res.model, res.saturated - res.null)
+
+                    # the clamp in Likelihood.r2 would hide a negative value
+                    assert np.isclose(0, 1.0 - res.ss_res / res.ss_tot)
+
+                with subtests.test("saturated model"):
+                    r2 = likelihood.r2(view, likelihood.transform_data(view, group_name), group_name)
+                    assert np.isclose(1, r2)
+
+                with subtests.test("intermediate model"):
+                    r2 = likelihood.r2(view, likelihood.transform_data(0.5 * (null + view), group_name), group_name)
+                    assert 0.05 < r2 < 1
+
+    @pytest.mark.parametrize(
+        "r2", (R2(np.nan, 1.0), R2(1.0, np.nan), R2(0.0, 0.0)), ids=("nan_res", "nan_tot", "zero_deviance")
+    )
+    def test_degenerate_is_nan(self, likelihoods, y_true, r2, monkeypatch):
+        # a degenerate null model must not be turned into a plausible-looking 0 by the clamp
+        for view_name, likelihood in likelihoods.items():
+            func = lambda *args, **kwargs: r2
+            monkeypatch.setattr(likelihood, "_deviance_explained_impl", func)
+            monkeypatch.setattr(likelihood, "_r2_impl", func)
+            for group_name, group in y_true.items():
+                view = group[view_name]
+                if issparse(view):
+                    view = view.toarray()
+                assert np.isnan(likelihood.r2(view, np.broadcast_to(0, view.shape), group_name))
+
+    @pytest.mark.parametrize("r2", (R2(np.inf, 1.0), R2(1.0, 0.0)), ids=("inf_res", "zero_tot"))
+    def test_degenerate_clamps(self, likelihoods, y_true, r2, monkeypatch):
+        # the model is infinitely worse than the null model, e.g. a count of zero predicted for a nonzero observation
+        for view_name, likelihood in likelihoods.items():
+            func = lambda *args, **kwargs: r2
+            monkeypatch.setattr(likelihood, "_deviance_explained_impl", func)
+            monkeypatch.setattr(likelihood, "_r2_impl", func)
+            for group_name, group in y_true.items():
+                view = group[view_name]
+                if issparse(view):
+                    view = view.toarray()
+                assert likelihood.r2(view, np.broadcast_to(0, view.shape), group_name) == 0
+
+
+class TestNormal(_TestLikelihood):
     @pytest.fixture(scope="class", params=[True, False])
     def scale_per_group(self, request):
         return request.param
@@ -93,19 +153,17 @@ class TestNormal:
     def dataset(self, adata_dict):
         return MofaFlexDataset(adata_dict("Normal"), cast_to=None)
 
-    def test_center_data(self, likelihoods, dataset, nonnegative):
-        result = dataset.__getitems__(sample_all_data_as_one_batch(dataset))["data"]
-        for group_name, group in result.items():
+    def test_center_data(self, likelihoods, y_true, nonnegative):
+        for group_name, group in y_true.items():
             for view_name, view in group.items():
                 if nonnegative[view_name]:
                     assert np.allclose(np.nanmin(view - likelihoods[view_name]._shift[group_name], axis=0), 0)
                 else:
                     assert np.allclose((view - likelihoods[view_name]._shift[group_name]).mean(axis=0), 0)
 
-    def test_scale_data(self, likelihoods, dataset, scale_per_group):
-        result = dataset.__getitems__(sample_all_data_as_one_batch(dataset))["data"]
+    def test_scale_data(self, likelihoods, dataset, y_true, scale_per_group):
         if scale_per_group:
-            for group_name, group in result.items():
+            for group_name, group in y_true.items():
                 for view_name, view in group.items():
                     assert np.allclose(
                         (
@@ -119,7 +177,7 @@ class TestNormal:
                 concat = np.concat(
                     [
                         group[view_name] - likelihoods[view_name]._shift[group_name]
-                        for group_name, group in result.items()
+                        for group_name, group in y_true.items()
                         if view_name in group
                     ],
                     axis=0,
@@ -127,7 +185,7 @@ class TestNormal:
                 assert np.allclose((concat / likelihoods[view_name]._scale).var(), 1)
 
 
-class TestBernoulli:
+class TestBernoulli(_TestLikelihood):
     @pytest.fixture(scope="class")
     def likelihoods(self, dataset, nonnegative):
         return {view_name: Bernoulli(view_name, dataset, nn) for view_name, nn in nonnegative.items()}
@@ -136,9 +194,8 @@ class TestBernoulli:
     def dataset(self, adata_dict, sparse_arr):
         return MofaFlexDataset(adata_dict("Bernoulli", sparse_arr), cast_to=None)
 
-    def test_center_data(self, likelihoods, dataset, nonnegative):
-        result = dataset.__getitems__(sample_all_data_as_one_batch(dataset))["data"]
-        for group_name, group in result.items():
+    def test_center_data(self, likelihoods, y_true, nonnegative):
+        for group_name, group in y_true.items():
             for view_name, view in group.items():
                 assert np.allclose(np.nanmean(view - expit(likelihoods[view_name]._shift[group_name]), axis=0), 0)
 
@@ -148,18 +205,24 @@ class TestBernoulli:
         np.testing.assert_allclose(bernoulli.logpmf(targets, expit(logits)), Bernoulli._logpmf(targets, logits))
 
 
-class TestNegativeBinomial:
+class TestNegativeBinomial(_TestLikelihood):
     @pytest.fixture(scope="class")
     def likelihoods(self, dataset, nonnegative):
-        return {view_name: NegativeBinomial(view_name, dataset, nn) for view_name, nn in nonnegative.items()}
+        ret = {}
+        for view_name, nn in nonnegative.items():
+            likelihood = NegativeBinomial(view_name, dataset, nn)
+            likelihood._dispersion = MeanStd(
+                np.full(dataset.n_features[view_name], 0.1), None
+            )  # not trained, so set manually
+            ret[view_name] = likelihood
+        return ret
 
     @pytest.fixture(scope="class")
     def dataset(self, adata_dict, sparse_arr):
         return MofaFlexDataset(adata_dict("NegativeBinomial", sparse_arr), cast_to=None)
 
-    def test_center_data(self, likelihoods, dataset, nonnegative):
-        result = dataset.__getitems__(sample_all_data_as_one_batch(dataset))["data"]
-        for group_name, group in result.items():
+    def test_center_data(self, likelihoods, y_true, nonnegative):
+        for group_name, group in y_true.items():
             for view_name, view in group.items():
                 if nonnegative[view_name]:
                     assert np.allclose(np.nanmin(view - likelihoods[view_name]._shift[group_name], axis=0), 0)
@@ -171,96 +234,3 @@ class TestNegativeBinomial:
                         ).mean(axis=0),
                         0,
                     )
-
-
-_group_name = "group_0"
-_view_name = "view_0"
-
-
-class TestDevianceExplained:
-    """Fixed points of the fraction of deviance explained for nonnegative views."""
-
-    @pytest.fixture(scope="class", params=[False, True], ids=["nonan", "withnan"])
-    def y_true(self, rng, likelihood, request):
-        match likelihood:
-            case "Normal":
-                arr = np.abs(rng.standard_normal(size=(50, 10)))
-            case "Bernoulli":
-                arr = rng.binomial(1, 0.3, size=(50, 10)).astype(np.float64)
-            case "NegativeBinomial":
-                # low mean, so that most features have a zero minimum, exercising the epsilon-regularized null model
-                arr = rng.negative_binomial(0.5, 0.3, size=(50, 10)).astype(np.float64)
-        arr[0, 0] = 0
-        if request.param:
-            arr[rng.random(arr.shape) < 0.1] = np.nan
-        return arr
-
-    @pytest.fixture(scope="class")
-    def likelihood_obj(self, likelihood, y_true, create_adata):
-        dataset = MofaFlexDataset({_group_name: {_view_name: create_adata(y_true)}}, cast_to=None)
-        obj = Likelihood.known_likelihoods()[likelihood](_view_name, dataset, True)
-        if isinstance(obj, NegativeBinomial):
-            obj._dispersion = MeanStd(np.full(y_true.shape[1], 0.1), None)  # not trained, so set manually
-        return obj
-
-    @staticmethod
-    def _raw_prediction(obj, target):
-        """Invert transform_prediction: the raw linear predictor which predicts `target` on the scale of the data."""
-        shift = obj._shift[_group_name]
-        match obj:
-            case Normal():
-                return (target - shift) / obj._scale[_group_name]
-            case Bernoulli():
-                return logit(np.clip(target, settings.eps, 1 - settings.eps)) - shift
-            case NegativeBinomial():
-                return target / obj._sample_means[_group_name] - shift
-
-    @staticmethod
-    def _null_target(obj, y_true):
-        """The prediction of the null model, on the scale of the data."""
-        match obj:
-            case Normal():
-                return np.broadcast_to(obj._shift[_group_name], y_true.shape)
-            case Bernoulli():
-                null_probability = np.clip(nanmin(y_true, axis=0), settings.eps, 1 - settings.eps)
-                return np.broadcast_to(null_probability, y_true.shape)
-            case NegativeBinomial():
-                sample_means = obj._sample_means[_group_name]
-                return np.maximum(obj._shift[_group_name], settings.eps) * sample_means
-
-    @staticmethod
-    def _unclamped(obj, y_true, y_pred):
-        """The fraction of deviance explained without the clamp to nonnegative values applied by Likelihood.r2."""
-        res = obj._deviance_explained_impl(y_true, y_pred, _group_name)
-        if isinstance(res, LogLikelihoods):
-            res = R2(res.saturated - res.model, res.saturated - res.null)
-        return 1.0 - res.ss_res / res.ss_tot
-
-    def test_null_model(self, likelihood_obj, y_true):
-        y_pred = self._raw_prediction(likelihood_obj, self._null_target(likelihood_obj, y_true))
-        # the clamp in Likelihood.r2 would hide a negative value
-        assert self._unclamped(likelihood_obj, y_true, y_pred) == pytest.approx(0, abs=1e-6)
-
-    def test_saturated_model(self, likelihood_obj, y_true):
-        y_pred = self._raw_prediction(likelihood_obj, y_true)
-        assert likelihood_obj.r2(y_true, y_pred, _group_name) == pytest.approx(1, abs=1e-6)
-
-    def test_intermediate_model(self, likelihood_obj, y_true):
-        # halfway between the null and saturated models should score strictly between 0 and 1.
-        target = (self._null_target(likelihood_obj, y_true) + y_true) / 2
-        r2 = likelihood_obj.r2(y_true, self._raw_prediction(likelihood_obj, target), _group_name)
-        assert 0.05 < r2 < 1.0
-
-    @pytest.mark.parametrize(
-        "res", [R2(np.nan, 1.0), R2(1.0, np.nan), R2(0.0, 0.0)], ids=["nan_res", "nan_tot", "zero_deviance"]
-    )
-    def test_degenerate_is_nan(self, likelihood_obj, y_true, res, monkeypatch):
-        # a degenerate null model must not be turned into a plausible-looking 0 by the clamp
-        monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
-        assert np.isnan(likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name))
-
-    @pytest.mark.parametrize("res", [R2(np.inf, 1.0), R2(1.0, 0.0)], ids=["inf_res", "zero_tot"])
-    def test_degenerate_clamps(self, likelihood_obj, y_true, res, monkeypatch):
-        # the model is infinitely worse than the null model, e.g. a count of zero predicted for a nonzero observation
-        monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
-        assert likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name) == 0

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -8,7 +8,7 @@ from mofaflex import settings
 from mofaflex._core import MofaFlexDataset
 from mofaflex._core.likelihoods import Bernoulli, Likelihood, NegativeBinomial, Normal
 from mofaflex._core.likelihoods.base import R2, LogLikelihoods
-from mofaflex._core.utils import MeanStd, nanmean, sample_all_data_as_one_batch
+from mofaflex._core.utils import MeanStd, nanmin, sample_all_data_as_one_batch
 
 _sparse_arr = [csc_array, csc_matrix, csr_array, csr_matrix]
 
@@ -188,7 +188,7 @@ class TestDevianceExplained:
             case "Bernoulli":
                 arr = rng.binomial(1, 0.3, size=(50, 10)).astype(np.float64)
             case "NegativeBinomial":
-                # low mean, so that most features have a zero minimum, which is what breaks a shift-based null model
+                # low mean, so that most features have a zero minimum, exercising the epsilon-regularized null model
                 arr = rng.negative_binomial(0.5, 0.3, size=(50, 10)).astype(np.float64)
         arr[0, 0] = 0
         if request.param:
@@ -220,12 +220,13 @@ class TestDevianceExplained:
         """The prediction of the null model, on the scale of the data."""
         match obj:
             case Normal():
-                return np.broadcast_to(nanmean(y_true, axis=0), y_true.shape)
+                return np.broadcast_to(obj._shift[_group_name], y_true.shape)
             case Bernoulli():
-                return np.broadcast_to(expit(obj._shift[_group_name]), y_true.shape)
+                null_probability = np.clip(nanmin(y_true, axis=0), settings.eps, 1 - settings.eps)
+                return np.broadcast_to(null_probability, y_true.shape)
             case NegativeBinomial():
                 sample_means = obj._sample_means[_group_name]
-                return nanmean(y_true / sample_means, axis=0) * sample_means
+                return np.maximum(obj._shift[_group_name], settings.eps) * sample_means
 
     @staticmethod
     def _unclamped(obj, y_true, y_pred):
@@ -245,26 +246,21 @@ class TestDevianceExplained:
         assert likelihood_obj.r2(y_true, y_pred, _group_name) == pytest.approx(1, abs=1e-6)
 
     def test_intermediate_model(self, likelihood_obj, y_true):
-        # halfway between the null and the saturated model. Guards against a degenerate null model, which makes
-        # everything score close to 1.
+        # halfway between the null and saturated models should score strictly between 0 and 1.
         target = (self._null_target(likelihood_obj, y_true) + y_true) / 2
         r2 = likelihood_obj.r2(y_true, self._raw_prediction(likelihood_obj, target), _group_name)
-        assert 0.05 < r2 < 0.95
+        assert 0.05 < r2 < 1.0
 
     @pytest.mark.parametrize(
-        "res",
-        [R2(np.nan, 1.0), R2(1.0, np.nan), R2(1.0, np.inf), R2(1.0, 0.0)],
-        ids=["nan_res", "nan_tot", "inf_tot", "zero_tot"],
+        "res", [R2(np.nan, 1.0), R2(1.0, np.nan), R2(0.0, 0.0)], ids=["nan_res", "nan_tot", "zero_deviance"]
     )
-    def test_degenerate_raises(self, likelihood_obj, y_true, res, monkeypatch):
-        # a degenerate null model must not be silently turned into a plausible-looking 0 by the clamp
+    def test_degenerate_is_nan(self, likelihood_obj, y_true, res, monkeypatch):
+        # a degenerate null model must not be turned into a plausible-looking 0 by the clamp
         monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
-        with pytest.raises(ValueError, match="Cannot calculate R2"):
-            likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name)
+        assert np.isnan(likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name))
 
-    @pytest.mark.parametrize("res", [R2(0.0, 0.0), R2(np.inf, 1.0)], ids=["nothing_to_explain", "inf_res"])
+    @pytest.mark.parametrize("res", [R2(np.inf, 1.0), R2(1.0, 0.0)], ids=["inf_res", "zero_tot"])
     def test_degenerate_clamps(self, likelihood_obj, y_true, res, monkeypatch):
-        # the null model is a perfect fit (e.g. a group with a single sample), or the model is infinitely worse
-        # than the null model (e.g. a count of zero predicted for a nonzero observation)
+        # the model is infinitely worse than the null model, e.g. a count of zero predicted for a nonzero observation
         monkeypatch.setattr(likelihood_obj, "_deviance_explained_impl", lambda *args, **kwargs: res)
         assert likelihood_obj.r2(y_true, np.zeros_like(y_true), _group_name) == 0


### PR DESCRIPTION
R2 as a measure of variance explained is not well defined for non-negative views, where the null model predicts the minimum of the data. It also doesn't even work at all for negative binomial views, since the R2 calculation contains a division by the data mimimum, which will be 0 in most cases.

Instead, use the fraction of deviance explained for nonnegative views. It reduces to R2 for Gaussian likelihoods and has a sufficiently similar interpretation.