### PR TITLE
imputation: implement imputation for missing summary statistics

### DIFF
--- a/src/mofaflex/_core/likelihoods/base.py
+++ b/src/mofaflex/_core/likelihoods/base.py
@@ -8,6 +8,9 @@ import numpy as np
 from anndata import AnnData
 from array_api_compat import array_namespace
 from scipy.sparse import issparse
+from sklearn.experimental import enable_iterative_imputer  # noqa: F401
+from sklearn.impute import IterativeImputer
+from sklearn.linear_model import BayesianRidge
 
 from ..api.utils import DynamicAPIMixin
 from ..datasets import MofaFlexDataset
@@ -61,6 +64,11 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
         """
         self._pyro_likelihood = self._get_pyro_likelihood(data, sample_dim, feature_dim)
         return self._pyro_likelihood
+
+    def _impute_feature_summary_statistics(self, stats: Mapping[str, Vector[np.number]], missing_values=np.nan):
+        imputer = IterativeImputer(estimator=BayesianRidge(), missing_values=missing_values, initial_strategy="mean")
+        imputed = imputer.fit_transform(np.stack(tuple(stats.values()), axis=0))
+        return dict(zip(stats.keys(), np.unstack(imputed, axis=0), strict=True))
 
     @abstractmethod
     def _get_pyro_likelihood(self, data: MofaFlexDataset, sample_dim: int, feature_dim: int) -> PyroLikelihood:
@@ -178,11 +186,11 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
     @abstractmethod
     def transform_prediction(
         self,
-        prediction: Matrix[np.floating],
+        prediction: Matrix[np.floating] | Vector[np.floating],
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
-    ) -> Matrix[np.floating]:
+    ) -> Matrix[np.floating] | Vector[np.floating]:
         """Transform the raw model prediction into something compatible with the data, a.k.a. inverse link function.
 
         Args:
@@ -234,6 +242,7 @@ class Likelihood(DynamicAPIMixin, SaveStateMixin, ABC):
             sample_idx,
             feature_idx,
         )
+
         return max(0.0, 1.0 - r2.ss_res / r2.ss_tot)
 
     def _load(self, state: Mapping[str, Any], feature_names: Vector[str], **kwargs):

--- a/src/mofaflex/_core/likelihoods/bernoulli.py
+++ b/src/mofaflex/_core/likelihoods/bernoulli.py
@@ -41,6 +41,9 @@ class Bernoulli(Likelihood):
             shift=self._shift,
         )
 
+    def on_train_end(self, *args, **kwargs):
+        self._shift = self._impute_feature_summary_statistics(self._shift)
+
     @classmethod
     def _validate(cls, data: Matrix[np.number], xp) -> bool:
         return xp.all(xp.isclose(data, 0) | xp.isclose(data, 1))  # TODO: set correct atol value
@@ -63,11 +66,11 @@ class Bernoulli(Likelihood):
 
     def transform_prediction(
         self,
-        prediction: Matrix[np.floating],
+        prediction: Matrix[np.floating] | Vector[np.floating],
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
-    ) -> Matrix[np.floating]:
+    ) -> Matrix[np.floating] | Vector[np.floating]:
         return expit(prediction + self._shift[group_name][feature_idx])
 
     def transform_data(

--- a/src/mofaflex/_core/likelihoods/negativebinomial.py
+++ b/src/mofaflex/_core/likelihoods/negativebinomial.py
@@ -55,6 +55,9 @@ class NegativeBinomial(Likelihood):
 
     def on_train_end(self, *args, **kwargs):
         self._dispersion = self._pyro_likelihood.dispersion
+        self._shift = self._impute_feature_summary_statistics(self._shift)
+        for means in self._sample_means.values():
+            means[np.isnan(means)] = np.nanmean(means)
 
     @classmethod
     def _validate(cls, data: Matrix, xp) -> bool:
@@ -82,14 +85,17 @@ class NegativeBinomial(Likelihood):
 
     def transform_prediction(
         self,
-        prediction: Matrix[np.floating],
+        prediction: Matrix[np.floating] | Vector[np.floating],
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
-    ) -> Matrix[np.floating]:
+    ) -> Matrix[np.floating] | Vector[np.floating]:
         prediction = prediction + self._shift[group_name][feature_idx]
         prediction = np.maximum(0, prediction)  # ReLU
-        prediction *= self._sample_means[group_name][sample_idx]
+        sample_means = self._sample_means[group_name][sample_idx]
+        if prediction.ndim == 1 and prediction.size == sample_idx.size == feature_idx.size:
+            sample_means = sample_means.squeeze(-1)
+        prediction *= sample_means
         return prediction
 
     def transform_data(

--- a/src/mofaflex/_core/likelihoods/normal.py
+++ b/src/mofaflex/_core/likelihoods/normal.py
@@ -84,6 +84,7 @@ class Normal(Likelihood):
 
     def on_train_end(self, *args, **kwargs):
         self._dispersion = self._pyro_likelihood.dispersion
+        self._shift = self._impute_feature_summary_statistics(self._shift)
 
     @classmethod
     def _validate(cls, data: Matrix[np.number], xp) -> bool:
@@ -103,11 +104,11 @@ class Normal(Likelihood):
 
     def transform_prediction(
         self,
-        prediction: Matrix[np.floating],
+        prediction: Matrix[np.floating] | Vector[np.floating],
         group_name: str,
         sample_idx: Vector[int] | slice = slice(None),
         feature_idx: Vector[int] | slice = slice(None),
-    ) -> Matrix[np.floating]:
+    ) -> Matrix[np.floating] | Vector[np.floating]:
         try:
             scale = self._scale[group_name]
         except IndexError:

--- a/src/mofaflex/_core/model.py
+++ b/src/mofaflex/_core/model.py
@@ -11,7 +11,7 @@ import pyro
 import torch
 from anndata import AnnData
 from pyro.nn import PyroModule, pyro_method
-from scipy.sparse import issparse
+from scipy.sparse import dok_array, issparse
 
 from .api.likelihoods import Likelihood as APILikelihood
 from .datasets import MofaFlexDataset, StackDataset
@@ -468,7 +468,16 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
         )
 
     def _impute(
-        self, data: AnnData, group_name, view_name, sample_names, feature_names, likelihood, missingonly, preprocessor
+        self,
+        data: AnnData,
+        group_name,
+        view_name,
+        sample_names,
+        feature_names,
+        likelihood,
+        missingonly,
+        preprocessor,
+        apply_link,
     ) -> AnnData:
         havemissing = data.n_obs < self._n_samples[group_name] or data.n_vars < self._n_features[view_name]
         if issparse(data.X):
@@ -482,6 +491,8 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
 
         if not missingonly:
             imputation = self.predict(group_name, view_name)
+            if apply_link:
+                imputation = likelihood.transform_prediction(imputation, group_name)
         else:
             missing_obs = align_local_array_to_global(  # noqa F821
                 np.broadcast_to(False, (data.n_obs,)), group_name, view_name, fill_value=True, align_to="samples"
@@ -490,33 +501,53 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
                 np.broadcast_to(False, (data.n_vars)), group_name, view_name, fill_value=True, align_to="features"
             )
 
-            preprocessed = preprocessor(data.X, slice(None), slice(None), group_name, view_name)[0]
-            if issparse(preprocessed):
-                preprocessed = preprocessed.toarray()
-
             obsidx = map_local_indices_to_global(np.arange(data.n_obs), group_name, view_name, align_to="samples")  # noqa: F821
             varidx = map_local_indices_to_global(np.arange(data.n_vars), group_name, view_name, align_to="features")  # noqa: F821
-            imputation = np.empty((sample_names.size, feature_names.size), dtype=data.X.dtype)
-            imputation[np.ix_(obsidx, varidx)] = likelihood.transform_data(preprocessed, group_name, obsidx, varidx)
 
-            imputation[missing_obs, :] = self.predict(group_name, view_name, sample_idx=missing_obs)
-            imputation[:, missing_var] = self.predict(group_name, view_name, feature_idx=missing_var)
+            if not apply_link or not issparse(data.X):
+                imputation = np.empty((sample_names.size, feature_names.size), dtype=data.X.dtype)
+            else:
+                imputation = dok_array((sample_names.size, feature_names.size), dtype=data.X.dtype)
+            if not apply_link:
+                preprocessed = preprocessor(data.X, slice(None), slice(None), group_name, view_name)[0]
+                if issparse(preprocessed):
+                    preprocessed = preprocessed.toarray()
+
+                imputation[np.ix_(obsidx, varidx)] = likelihood.transform_data(preprocessed, group_name, obsidx, varidx)
+            else:
+                imputation[np.ix_(obsidx, varidx)] = data.X
+
+            pred_obs = self.predict(group_name, view_name, sample_idx=missing_obs)
+            pred_var = self.predict(group_name, view_name, feature_idx=missing_var)
+
+            if apply_link:
+                pred_obs = likelihood.transform_prediction(pred_obs, group_name, sample_idx=missing_obs)
+                pred_var = likelihood.transform_prediction(pred_var, group_name, feature_idx=missing_var)
+            imputation[missing_obs, :] = pred_obs
+            imputation[:, missing_var] = pred_var
 
             if have_missing_cells:
                 nanobs, nanvar = wherenan(data.X)
                 nanobs, nanvar = np.atleast_1d(obsidx[nanobs]), np.atleast_1d(varidx[nanvar])
-                imputation[nanobs, nanvar] = self.predict(
-                    group_name, view_name, nanobs, nanvar, idx_cartesian_product=False
-                )
+                pred = self.predict(group_name, view_name, nanobs, nanvar, idx_cartesian_product=False)
+                if apply_link:
+                    pred = likelihood.transform_prediction(pred, group_name, sample_idx=nanobs, feature_idx=nanvar)
+                imputation[nanobs, nanvar] = pred
+
+            if issparse(imputation):
+                imputation = imputation.tocsr()
 
         return AnnData(X=imputation, obs=pd.DataFrame(index=sample_names), var=pd.DataFrame(index=feature_names))
 
-    def impute(self, data: MofaFlexDataset, missing_only=False) -> dict[dict[str, AnnData]]:
+    def impute(self, data: MofaFlexDataset, missing_only=False, apply_link=True) -> dict[dict[str, AnnData]]:
         """Impute values in the training data using the trained factorization.
 
         Args:
             data: The data the model was trained on.
             missing_only: Only impute missing values in the data.
+            apply_link: Whether to apply the likelihood-specific link function to imputed values. If `False`, the
+                returned data will be simply the matrix product of factors and weights. If `True`, the returned
+                data will be transformed using a likelihood-specific link function.
 
         Returns:
             Nested dictionary of AnnData objects with either fully imputed data or with only the missing values filled in.
@@ -529,6 +560,7 @@ class MofaFlexModel(SaveStateMixin, PyroModule):
             group_kwargs={"sample_names": data.sample_names},
             missingonly=missing_only,
             preprocessor=data.preprocessor,
+            apply_link=apply_link,
         )
 
     def _save(self) -> dict[str, Any]:

--- a/src/mofaflex/_core/mofaflex.py
+++ b/src/mofaflex/_core/mofaflex.py
@@ -500,24 +500,26 @@ class MOFAFLEX:
 
     @_check_trained
     def impute_data(
-        self, data: MuData | Mapping[str, Mapping[str, AnnData]] | AnnData, missing_only=False
+        self, data: MuData | Mapping[str, Mapping[str, AnnData]] | AnnData, missing_only=False, apply_link=True
     ) -> dict[dict[str, AnnData]]:
         """Impute values in the training data using the trained factorization.
-
-        The data will be transformed into a space compatible with model predictions. Usually that involves shifting and/or
-        scaling, e.g. Gaussian data will be mean-centered and scaled to unit variance. This also implies that only dense
-        matrices can be returned. Be aware that this can result in high memory consumption.
 
         Args:
             data: The data the model was trained on.
             missing_only: Only impute missing values in the data.
+            apply_link: Whether to apply the likelihood-specific link function to the imputed values. If `True`, predictions
+                will be transformed into data space. If `False`, predictions are simply the matrix product of factors and
+                weights. If additionally `missing_only=True`, the non-missing data will be transformed into a space compatible
+                with model predictions. Usually that involves shifting and/or scaling, e.g. Gaussian data will be mean-centered
+                and scaled to unit variance. This also implies that only dense matrices can be returned. Be aware that this
+                can result in high memory consumption.
 
         Returns:
             Nested dictionary of AnnData objects with either fully imputed data or with only the missing values filled in.
         """
         data = self._make_dataset(data)
         data.reindex_features(self.feature_names)
-        return self._model.impute(data, missing_only)
+        return self._model.impute(data, missing_only, apply_link=apply_link)
 
     def _save(self, path: str | Path):
         state = {

--- a/tests/test_mofaflex_integration.py
+++ b/tests/test_mofaflex_integration.py
@@ -448,8 +448,9 @@ def test_integration_covariates_singlegroup(anndata_dict, tmp_path, select, n_pa
     assert list(model.factor_covariates.keys()) == [selected_group]
 
 
+@pytest.mark.parametrize("apply_link", [False, True])
 @pytest.mark.parametrize("usedask", [False, True])
-def test_imputation(rng, anndata_dict, usedask):
+def test_imputation(rng, anndata_dict, usedask, apply_link):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=SparseEfficiencyWarning)
 
@@ -468,16 +469,16 @@ def test_imputation(rng, anndata_dict, usedask):
     with settings.override(use_dask=usedask):
         model = terms.MofaFlex(n_factors=5)
         with pytest.raises(RuntimeError, match="not yet trained"):
-            model.impute_data()
+            model.impute_data(apply_link=apply_link)
         model.fit(anndata_dict, plot_data_overview=False, max_epochs=5, seed=42, save_path=False)
 
-        imputed = model.impute_data(anndata_dict, missing_only=False)
+        imputed = model.impute_data(anndata_dict, missing_only=False, apply_link=apply_link)
 
     for group in imputed.values():
         for view in group.values():
             assert np.isnan(view.X if not issparse(view.X) else view.X.data).sum() == 0
 
-    imputed = model.impute_data(anndata_dict, missing_only=True)
+    imputed = model.impute_data(anndata_dict, missing_only=True, apply_link=apply_link)
     dataset = model._make_dataset(anndata_dict)
     preprocessor = dataset.preprocessor
     for group_name, group in imputed.items():
@@ -492,13 +493,14 @@ def test_imputation(rng, anndata_dict, usedask):
             if issparse(new_X):
                 new_X = new_X.toarray()
             nonnan = ~np.isnan(orig_X)
-            orig_X = preprocessor(orig_X, slice(None), slice(None), group_name, view_name)[0]
-            orig_X = model._model._likelihoods[view_name].transform_data(
-                orig_X,
-                group_name,
-                dataset.map_local_indices_to_global(slice(None), group_name, view_name, align_to="samples"),
-                dataset.map_local_indices_to_global(slice(None), group_name, view_name, align_to="features"),
-            )
+            if not apply_link:
+                orig_X = preprocessor(orig_X, slice(None), slice(None), group_name, view_name)[0]
+                orig_X = model._model._likelihoods[view_name].transform_data(
+                    orig_X,
+                    group_name,
+                    dataset.map_local_indices_to_global(slice(None), group_name, view_name, align_to="samples"),
+                    dataset.map_local_indices_to_global(slice(None), group_name, view_name, align_to="features"),
+                )
             assert np.allclose(orig_X[nonnan], new_X[nonnan])
 
 


### PR DESCRIPTION
This allows transforming imputed data into data space. For feature-level statistics, this uses sklearn's IterativeImputer, which seems to give reasonable results. Sample means for the negative binomial likelihood are imputed using the mean of the distribution for each group and view.

Imputation of summary statistics happens directly after training, so the imputed values are saved to disk and the same values are used for all subsequent calls to `impute_data()`.

`impute_data()` gains an additional argument `apply_link` that determines whether to return the imputed values in latent space or in data space.